### PR TITLE
Implementation for coalescing white spaces in description of RowDoesNotExistAssertion and RowExistsAssertion

### DIFF
--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/framework/Util.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/framework/Util.java
@@ -32,4 +32,9 @@ public class Util
 
 		return uri.substring(index + 1);
 	}
+
+	public static String coalesceWhiteSpaces(String text){
+		return text.replaceAll("\\s+", " ").trim();
+	}
 }
+

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/framework/Util.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/framework/Util.java
@@ -33,7 +33,9 @@ public class Util
 		return uri.substring(index + 1);
 	}
 
-	public static String coalesceWhiteSpaces(String text){
+	public static String coalesceWhitespace(String text)
+	{
+		if (text == null) { throw new IllegalArgumentException("text cannot be null"); }
 		return text.replaceAll("\\s+", " ").trim();
 	}
 }

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/dom/RowDoesNotExistDomAssertionBuilder.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/dom/RowDoesNotExistDomAssertionBuilder.java
@@ -28,6 +28,8 @@ import co.mv.wb.plugin.generaldatabase.RowExistsAssertion;
 import java.util.Optional;
 import java.util.UUID;
 
+import static co.mv.wb.framework.Util.coalesceWhiteSpaces;
+
 /**
  * An {@link AssertionBuilder} that builds a {@link RowDoesNotExistAssertion} from a DOM {@link org.w3c.dom.Element}.
  * 
@@ -60,7 +62,8 @@ public class RowDoesNotExistDomAssertionBuilder extends BaseDomAssertionBuilder
 		{
 			throw new PluginBuildException(messages);
 		}
-		
-		return new RowDoesNotExistAssertion(assertionId, description.get(), seqNum, sql.get());
+
+
+		return new RowDoesNotExistAssertion(assertionId, coalesceWhiteSpaces(description.get()), seqNum, sql.get());
 	}
 }

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/dom/RowDoesNotExistDomAssertionBuilder.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/dom/RowDoesNotExistDomAssertionBuilder.java
@@ -28,7 +28,7 @@ import co.mv.wb.plugin.generaldatabase.RowExistsAssertion;
 import java.util.Optional;
 import java.util.UUID;
 
-import static co.mv.wb.framework.Util.coalesceWhiteSpaces;
+import static co.mv.wb.framework.Util.coalesceWhitespace;
 
 /**
  * An {@link AssertionBuilder} that builds a {@link RowDoesNotExistAssertion} from a DOM {@link org.w3c.dom.Element}.
@@ -64,6 +64,6 @@ public class RowDoesNotExistDomAssertionBuilder extends BaseDomAssertionBuilder
 		}
 
 
-		return new RowDoesNotExistAssertion(assertionId, coalesceWhiteSpaces(description.get()), seqNum, sql.get());
+		return new RowDoesNotExistAssertion(assertionId, coalesceWhitespace(description.get()), seqNum, sql.get());
 	}
 }

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/dom/RowExistsDomAssertionBuilder.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/dom/RowExistsDomAssertionBuilder.java
@@ -27,6 +27,8 @@ import co.mv.wb.plugin.generaldatabase.RowExistsAssertion;
 import java.util.Optional;
 import java.util.UUID;
 
+import static co.mv.wb.framework.Util.coalesceWhiteSpaces;
+
 /**
  * An {@link AssertionBuilder} that builds a {@link RowExistsAssertion} from a DOM {@link org.w3c.dom.Element}.
  * 
@@ -60,6 +62,6 @@ public class RowExistsDomAssertionBuilder extends BaseDomAssertionBuilder implem
 			throw new PluginBuildException(messages);
 		}
 		
-		return new RowExistsAssertion(assertionId, description.get(), seqNum, sql.get());
+		return new RowExistsAssertion(assertionId, coalesceWhiteSpaces(description.get()), seqNum, sql.get());
 	}
 }

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/dom/RowExistsDomAssertionBuilder.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/dom/RowExistsDomAssertionBuilder.java
@@ -27,7 +27,7 @@ import co.mv.wb.plugin.generaldatabase.RowExistsAssertion;
 import java.util.Optional;
 import java.util.UUID;
 
-import static co.mv.wb.framework.Util.coalesceWhiteSpaces;
+import static co.mv.wb.framework.Util.coalesceWhitespace;
 
 /**
  * An {@link AssertionBuilder} that builds a {@link RowExistsAssertion} from a DOM {@link org.w3c.dom.Element}.
@@ -62,6 +62,6 @@ public class RowExistsDomAssertionBuilder extends BaseDomAssertionBuilder implem
 			throw new PluginBuildException(messages);
 		}
 		
-		return new RowExistsAssertion(assertionId, coalesceWhiteSpaces(description.get()), seqNum, sql.get());
+		return new RowExistsAssertion(assertionId, coalesceWhitespace(description.get()), seqNum, sql.get());
 	}
 }

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/framework/UtilTest.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/framework/UtilTest.java
@@ -1,0 +1,23 @@
+package co.mv.wb.framework;
+
+
+import org.junit.Assert;
+
+public class UtilTest {
+
+    @org.junit.Test
+    public void coalesceWhiteSpacesSingleLine() {
+        String text = " Text with    extra spaces.  In the start, middle and end ";
+        String expected = "Text with extra spaces. In the start, middle and end";
+        String result = Util.coalesceWhiteSpaces(text);
+        Assert.assertEquals("White spaces should be coalesce to single white space", expected, result);
+    }
+
+    @org.junit.Test
+    public void coalesceWhiteSpacesMultiLine() {
+        String text = " Text with    extra spaces.  \nIn the start, middle and end \n";
+        String expected = "Text with extra spaces. In the start, middle and end";
+        String result = Util.coalesceWhiteSpaces(text);
+        Assert.assertEquals("White spaces should be coalesce to single white space", expected, result);
+    }
+}

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/framework/UtilTest.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/framework/UtilTest.java
@@ -1,23 +1,42 @@
+// Wildebeest Migration Framework
+// Copyright © 2013 - 2018, Matheson Ventures Pte Ltd
+//
+// This file is part of Wildebeest
+//
+// Wildebeest is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License v2 as published by the Free
+// Software Foundation.
+//
+// Wildebeest is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Wildebeest.  If not, see http://www.gnu.org/licenses/gpl-2.0.html
+
 package co.mv.wb.framework;
 
-
 import org.junit.Assert;
+import org.junit.Test;
 
-public class UtilTest {
+public class UtilTest
+{
 
-    @org.junit.Test
-    public void coalesceWhiteSpacesSingleLine() {
+    @Test
+    public void coalesceWhiteSpacesSingleLine()
+    {
         String text = " Text with    extra spaces.  In the start, middle and end ";
         String expected = "Text with extra spaces. In the start, middle and end";
-        String result = Util.coalesceWhiteSpaces(text);
+        String result = Util.coalesceWhitespace(text);
         Assert.assertEquals("White spaces should be coalesce to single white space", expected, result);
     }
 
-    @org.junit.Test
-    public void coalesceWhiteSpacesMultiLine() {
+    @Test
+    public void coalesceWhiteSpacesMultiLine()
+    {
         String text = " Text with    extra spaces.  \nIn the start, middle and end \n";
         String expected = "Text with extra spaces. In the start, middle and end";
-        String result = Util.coalesceWhiteSpaces(text);
+        String result = Util.coalesceWhitespace(text);
         Assert.assertEquals("White spaces should be coalesce to single white space", expected, result);
     }
 }


### PR DESCRIPTION
Added coalesceWhiteSpaces method in Util.java.  This should make it reusable in other parts of the code.
Passed coalesced white spaces in the description for RowDoesNotExistAssertion and RowExistsAssertion
Added UtilTest to test if white space is coalesced properly.