### PR TITLE
MVWB-151 Retrieve ivy JAR to a shared location outside the component …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+/.build
 /out
 /repo
 /project.override.properties
@@ -7,4 +8,3 @@
 /MV.Wildebeest.Core/target/
 
 /website/source/rel
-

--- a/MV.Wildebeest.Api/build.xml
+++ b/MV.Wildebeest.Api/build.xml
@@ -204,7 +204,7 @@
 		<property name="target.test.javadoc" value="${target.test}/javadoc" />
 
 		<!-- Build Resource Targets -->
-		<property name="target.buildres" value="${target}/buildres" />
+		<property name="target.buildres" value="../.build" />
 		<property name="target.buildres.ivy" value="${target.buildres}/ivy" />
 
 		<!--

--- a/MV.Wildebeest.Core/build.xml
+++ b/MV.Wildebeest.Core/build.xml
@@ -204,7 +204,7 @@
 		<property name="target.test.javadoc" value="${target.test}/javadoc" />
 
 		<!-- Build Resource Targets -->
-		<property name="target.buildres" value="${target}/buildres" />
+		<property name="target.buildres" value="../.build" />
 		<property name="target.buildres.ivy" value="${target.buildres}/ivy" />
 
 		<!--


### PR DESCRIPTION
…builds - the .build/ directory at the project root.  Once retrieved this does not get cleaned up by the build scripts and requires a manual deletion to remove.