### PR TITLE
MVWB-152: Assert current state if valid before applying migrations.

### DIFF
--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/framework/Util.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/framework/Util.java
@@ -69,7 +69,7 @@ public class Util
 	 */
 	public static boolean isUUID(String value)
 	{
-		final String UUIDmatcher = "[a-zA-Z0-9][a-zA-Z0-9\\-\\_ ]+[a-zA-Z0-9]";
+		final String UUIDmatcher = "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}";
 		if (value.matches(UUIDmatcher))
 		{
 			return true;

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/impl/PluginManagerImpl.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/impl/PluginManagerImpl.java
@@ -113,7 +113,7 @@ public class PluginManagerImpl implements PluginManager
 	{
 		if (uri == null) throw new ArgumentNullException("uri");
 
-		if (migrationPlugins.containsKey(uri))
+		if (!migrationPlugins.containsKey(uri))
 		{
 			throw new RuntimeException(String.format("no MigrationPlugin found for uri: %s", uri));
 		}

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/impl/WildebeestApiBuilder.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/impl/WildebeestApiBuilder.java
@@ -135,4 +135,13 @@ public class WildebeestApiBuilder
 
 		return wildebeestApi;
 	}
+
+	public WildebeestApiBuilder withCustomResourcePlugins(Map<ResourceType,ResourcePlugin> resourcePlugins)
+	{
+		return new WildebeestApiBuilder(
+			wildebeestApi,
+			resourcePlugins,
+			pluginManager);
+	}
+
 }

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/impl/WildebeestApiImpl.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/impl/WildebeestApiImpl.java
@@ -361,6 +361,15 @@ public class WildebeestApiImpl implements WildebeestApi
 
 		validateMigrationStates(resource);
 
+		if (currentState != null)
+		{
+			List<AssertionResult> initialAssertionResults = this.assertState(
+				resource,
+				instance);
+
+			WildebeestApiImpl.throwIfFailed(currentState.getStateId(), initialAssertionResults);
+		}
+
 		for (Migration migration : path)
 		{
 			String migrationTypeUri = migration.getClass().getAnnotation(MigrationType.class).uri();
@@ -708,7 +717,7 @@ public class WildebeestApiImpl implements WildebeestApi
 				.stream()
 				.filter(m ->
 					(!m.getFromState().isPresent() && fromState == null) ||
-						(m.getFromState().isPresent() && m.getFromState().equals(fromState)))
+						(m.getFromState().isPresent() && m.getFromState().get().equals(fromState.toString())))
 				.forEach(
 					migration ->
 					{
@@ -772,7 +781,7 @@ public class WildebeestApiImpl implements WildebeestApi
 			boolean migrationFromStateValid = false;
 
 			//check do states exist in migration, if they don't set them to true so they don't throw errors
-			if (!m.getToState().isPresent())
+			if (!m.getFromState().isPresent())
 			{
 				migrationFromStateValid = true;
 			}
@@ -784,11 +793,11 @@ public class WildebeestApiImpl implements WildebeestApi
 			for (State s : states
 				)
 			{
-				if (m.getToState().equals(s.getStateId()) || m.getToState().equals(s.getLabel()))
+				if (m.getToState().isPresent() && (m.getToState().get().equals(s.getStateId().toString()) || m.getToState().get().equals(s.getLabel())))
 				{
 					migrationToStateValid = true;
 				}
-				if (m.getToState().equals(s.getStateId()) || m.getToState().equals(s.getLabel()))
+				if (m.getFromState().isPresent() && (m.getFromState().get().equals(s.getStateId().toString()) || m.getFromState().get().equals(s.getLabel())))
 				{
 					migrationFromStateValid = true;
 				}

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/fixture/TestContext_SimpleFakeResource_Builder.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/fixture/TestContext_SimpleFakeResource_Builder.java
@@ -16,6 +16,7 @@
 
 package co.mv.wb.fixture;
 
+import co.mv.wb.Assertion;
 import co.mv.wb.Instance;
 import co.mv.wb.Resource;
 import co.mv.wb.ResourcePlugin;
@@ -28,6 +29,7 @@ import co.mv.wb.plugin.fake.FakeConstants;
 import co.mv.wb.plugin.fake.FakeInstance;
 import co.mv.wb.plugin.fake.FakeResourcePlugin;
 import co.mv.wb.plugin.fake.SetTagMigration;
+import co.mv.wb.plugin.fake.TagAssertion;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -58,7 +60,7 @@ public class TestContext_SimpleFakeResource_Builder
 		return this;
 	}
 
-	public TestContext_SimpleFakeResource get()
+	public TestContext_SimpleFakeResource getResourceWithNonExistantInitialState()
 	{
 		Map<ResourceType, ResourcePlugin> resourcePlugins = new HashMap<>();
 		resourcePlugins.put(FakeConstants.Fake, new FakeResourcePlugin());
@@ -106,6 +108,52 @@ public class TestContext_SimpleFakeResource_Builder
 			fooState,
 			barStateId,
 			barState,
+			instance);
+	}
+
+	public TestContext_SimpleFakeResource getResourceWithInitialState()
+	{
+		Map<ResourceType, ResourcePlugin> resourcePlugins = new HashMap<>();
+		resourcePlugins.put(FakeConstants.Fake, new FakeResourcePlugin());
+
+		Resource resource = new ResourceImpl(
+			UUID.randomUUID(),
+			FakeConstants.Fake,
+			"MyResource",
+			Optional.ofNullable(defaultTarget));
+
+		UUID finalStateId = UUID.randomUUID();
+		State finalState = new ImmutableState(
+			finalStateId,
+			Optional.of("finalState"));
+		resource.getStates().add(finalState);
+		Assertion finalAssertion1 = new TagAssertion(
+			UUID.randomUUID(),
+			0,
+			"finalState");
+		finalState.getAssertions().add(finalAssertion1);
+
+		UUID initialStateId = UUID.randomUUID();
+		State initialState = new ImmutableState(
+			initialStateId,
+			Optional.of("initialState"));
+		resource.getStates().add(initialState);
+
+		resource.getMigrations().add(new SetTagMigration(
+			UUID.randomUUID(),
+			Optional.of(initialStateId.toString()),
+			Optional.of(finalStateId.toString()),
+			"finalState"));
+
+		Instance instance = new FakeInstance(initialStateId);
+		((FakeInstance)instance).setTag("initialState");
+		return new TestContext_SimpleFakeResource(
+			resourcePlugins,
+			resource,
+			finalStateId,
+			finalState,
+			initialStateId,
+			initialState,
 			instance);
 	}
 }

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/fake/SetTagMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/fake/SetTagMigrationPlugin.java
@@ -19,6 +19,7 @@ package co.mv.wb.plugin.fake;
 import co.mv.wb.Instance;
 import co.mv.wb.Migration;
 import co.mv.wb.MigrationPlugin;
+import co.mv.wb.MigrationPluginType;
 import co.mv.wb.ModelExtensions;
 import co.mv.wb.Resource;
 import co.mv.wb.State;
@@ -32,6 +33,7 @@ import java.io.PrintStream;
  *
  * @since 1.0
  */
+@MigrationPluginType(uri = "co.mv.wb.fake:SetTag")
 public class SetTagMigrationPlugin implements MigrationPlugin
 {
 	private final Resource resource;

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/fake/TagAssertion.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/fake/TagAssertion.java
@@ -45,6 +45,7 @@ import java.util.UUID;
 public class TagAssertion extends BaseAssertion
 {
 	private final String tag;
+	private int calledNTimes = 0;
 
 	public TagAssertion(
 		UUID assertionId,
@@ -67,6 +68,11 @@ public class TagAssertion extends BaseAssertion
 		return this.tag;
 	}
 
+	public int getCalledNTimes()
+	{
+		return this.calledNTimes;
+	}
+
 	@Override
 	public List<ResourceType> getApplicableTypes()
 	{
@@ -85,6 +91,7 @@ public class TagAssertion extends BaseAssertion
 			throw new IllegalArgumentException("instance must be a FakeInstance");
 		}
 
+		this.calledNTimes += 1;
 		AssertionResponse response;
 
 		if (this.getTag().equals(fake.getTag()))


### PR DESCRIPTION
a. Fixed regex for detecting UUID
b. Fixed wrong condition for checking if migration plugin exists.
c. Added method in WildebeestApiBuilder for specifying custom resource
plugin for unit test purposes.
d. Fixed bug where UUID object is compared to a String in WildebeestApiImpl
object which will result to always false condition.
e. Fixed bug in WildebeestApiImpl in checking for migrationFromStateValid
condition
f. Added a SimpleFakeResource that has an existant initial state for testing
intial state assertions
g. Added unit tests for checking non-existant initial state, existant initial
state successful premigration assertion and existant initial state pre-
migration assertion failed.