### PR TITLE
MVWB-159 : Added EventSink in place of PrintStream out

### DIFF
--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/MigrationPlugin.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/MigrationPlugin.java
@@ -16,7 +16,7 @@
 
 package co.mv.wb;
 
-import java.io.PrintStream;
+import co.mv.wb.event.EventSink;
 
 /**
  * MigrationPlugins actually perform {@link Migration}'s.  Runner plugins are separated from {@link Migration}'s so that
@@ -27,14 +27,14 @@ public interface MigrationPlugin
 	/**
 	 * Performs the migration, transitioning the supplied Instance from the Migration's from state to it's to state.
 	 *
-	 * @param output    the PrintStream for user output.
+	 * @param eventSink    the event sink that will process all events for user output
 	 * @param migration the Migration to apply to the supplied instance.
 	 * @param instance  the instance to be migrated
 	 * @throws MigrationFailedException if the migration fails
 	 * @since 1.0
 	 */
 	void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance) throws
 		MigrationFailedException;

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/ResourcePlugin.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/ResourcePlugin.java
@@ -16,7 +16,8 @@
 
 package co.mv.wb;
 
-import java.io.PrintStream;
+import co.mv.wb.event.EventSink;
+
 import java.util.UUID;
 
 /**
@@ -52,14 +53,13 @@ public interface ResourcePlugin
 
 	/**
 	 * Registers resource-type-specific meta data to record that it is in the specified state.
-	 *
-	 * @param output   the PrintStream for user output.
+	 *  @param eventSink the event sink that will process all events for user output
 	 * @param resource the resource for which the state should be set in the specified {@link Instance}
 	 * @param instance the {@link Instance} to record the state against
 	 * @param stateId  the state to record against the instance
 	 */
 	void setStateId(
-		PrintStream output,
+		EventSink eventSink,
 		Resource resource,
 		Instance instance,
 		UUID stateId);

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/AssertionEvent.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/AssertionEvent.java
@@ -1,0 +1,87 @@
+// Wildebeest Migration Framework
+// Copyright © 2013 - 2018, Matheson Ventures Pte Ltd
+//
+// This file is part of Wildebeest
+//
+// Wildebeest is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License v2 as published by the Free
+// Software Foundation.
+//
+// Wildebeest is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Wildebeest.  If not, see http://www.gnu.org/licenses/gpl-2.0.html
+
+package co.mv.wb.event;
+
+import java.util.Optional;
+
+/**
+ * Defines an event for Assertion
+ *
+ * @since 4.0
+ */
+public class AssertionEvent extends Event
+{
+	/**
+	 * Provides all events associated with Assertion.
+	 *
+	 * @since 4.0
+	 */
+	public enum Name
+	{
+		Start, Complete, Failed;
+	}
+
+	/**
+	 * Constructs a new AssertionEvent with the supplied details.
+	 *
+	 * @param name    the name of the event
+	 * @param message the message of the event
+	 * @since 4.0
+	 */
+	public AssertionEvent(
+		String name,
+		Optional<String> message)
+	{
+		super(name, message);
+	}
+
+	/**
+	 * Creates an AssertionEvent for Start Event.
+	 *
+	 * @param message the message of the event
+	 * @return the AssertionEvent created for Start Event
+	 * @since 4.0
+	 */
+	public static AssertionEvent start(Optional<String> message)
+	{
+		return new AssertionEvent(Name.Start.name(), message);
+	}
+
+	/**
+	 * Creates an AssertionEvent for Complete Event.
+	 *
+	 * @param message the message of the event
+	 * @return the AssertionEvent created for Complete Event
+	 * @since 4.0
+	 */
+	public static AssertionEvent complete(Optional<String> message)
+	{
+		return new AssertionEvent(Name.Complete.name(), message);
+	}
+
+	/**
+	 * Creates an AssertionEvent for Failed Event.
+	 *
+	 * @param message the message of the event
+	 * @return the AssertionEvent created for Failed Event
+	 * @since 4.0
+	 */
+	public static AssertionEvent failed(String message)
+	{
+		return new AssertionEvent(Name.Failed.name(), Optional.of(message));
+	}
+}

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/CommandLineEvent.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/CommandLineEvent.java
@@ -1,0 +1,174 @@
+// Wildebeest Migration Framework
+// Copyright © 2013 - 2018, Matheson Ventures Pte Ltd
+//
+// This file is part of Wildebeest
+//
+// Wildebeest is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License v2 as published by the Free
+// Software Foundation.
+//
+// Wildebeest is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Wildebeest.  If not, see http://www.gnu.org/licenses/gpl-2.0.html
+
+package co.mv.wb.event;
+
+import java.util.Optional;
+
+/**
+ * Defines an event for WildebeestCommand
+ *
+ * @since 4.0
+ */
+public class CommandLineEvent extends Event
+{
+	/**
+	 * Provides all events associated with Wildebeest Command.
+	 *
+	 * @since 4.0
+	 */
+	public enum Name
+	{
+		AboutStart, AboutFinish, StateCheckingFailed, MigrateFailed, JumpStateFailed, PluginsStart, PluginsFinish,
+		LoadResourceFailed, LoadInstanceFailed, InvalidArgument;
+	}
+
+	/**
+	 * Constructs a new CommandLineEvent with the supplied details.
+	 *
+	 * @param name    the name of the event
+	 * @param message the message of the event
+	 * @since 4.0
+	 */
+	public CommandLineEvent(
+		String name,
+		Optional<String> message)
+	{
+		super(name, message);
+	}
+
+
+	/**
+	 * Creates an CommandLineEvent for AboutStart Event.
+	 *
+	 * @param message the message of the event
+	 * @return the CommandLineEvent created for AboutStart Event
+	 * @since 4.0
+	 */
+	public static CommandLineEvent aboutStart(Optional<String> message)
+	{
+		return new CommandLineEvent(Name.AboutStart.name(), message);
+	}
+
+	/**
+	 * Creates an CommandLineEvent for AboutFinish Event.
+	 *
+	 * @param message the message of the event
+	 * @return the CommandLineEvent created for AboutFinish Event
+	 * @since 4.0
+	 */
+	public static CommandLineEvent aboutFinish(String message)
+	{
+		return new CommandLineEvent(Name.AboutFinish.name(), Optional.of(message));
+	}
+
+	/**
+	 * Creates an CommandLineEvent for StateCheckingFailed Event.
+	 *
+	 * @param message the message of the event
+	 * @return the CommandLineEvent created for StateCheckingFailed Event
+	 * @since 4.0
+	 */
+	public static Event stateCheckingFailed(String message)
+	{
+		return new CommandLineEvent(Name.StateCheckingFailed.name(), Optional.of(message));
+	}
+
+	/**
+	 * Creates an CommandLineEvent for MigrateFailed Event.
+	 *
+	 * @param message the message of the event
+	 * @return the CommandLineEvent created for MigrateFailed Event
+	 * @since 4.0
+	 */
+	public static Event migrateFailed(String message)
+	{
+		return new CommandLineEvent(Name.MigrateFailed.name(), Optional.of(message));
+	}
+
+	/**
+	 * Creates an CommandLineEvent for JumpStateFailed Event.
+	 *
+	 * @param message the message of the event
+	 * @return the CommandLineEvent created for JumpStateFailed Event
+	 * @since 4.0
+	 */
+	public static Event jumpStateFailed(String message)
+	{
+		return new CommandLineEvent(Name.JumpStateFailed.name(), Optional.of(message));
+	}
+
+	/**
+	 * Creates an CommandLineEvent for PluginsStart Event.
+	 *
+	 * @param message the message of the event
+	 * @return the CommandLineEvent created for PluginsStart Event
+	 * @since 4.0
+	 */
+	public static CommandLineEvent pluginsStart(Optional<String> message)
+	{
+		return new CommandLineEvent(Name.PluginsStart.name(), message);
+	}
+
+	/**
+	 * Creates an CommandLineEvent for PluginsFinish Event.
+	 *
+	 * @param message the message of the event
+	 * @return the CommandLineEvent created for PluginsFinish Event
+	 * @since 4.0
+	 */
+	public static CommandLineEvent pluginsFinish(String message)
+	{
+		return new CommandLineEvent(Name.PluginsFinish.name(), Optional.of(message));
+	}
+
+	/**
+	 * Creates an CommandLineEvent for LoadResourceFailed Event.
+	 *
+	 * @param message the message of the event
+	 * @return the CommandLineEvent created for LoadResourceFailed Event
+	 * @since 4.0
+	 */
+	public static Event loadResourceFailed(String message)
+	{
+		return new CommandLineEvent(Name.LoadResourceFailed.name(), Optional.of(message));
+	}
+
+	/**
+	 * Creates an CommandLineEvent for LoadInstanceFailed Event.
+	 *
+	 * @param message the message of the event
+	 * @return the CommandLineEvent created for LoadInstanceFailed Event
+	 * @since 4.0
+	 */
+	public static Event loadInstanceFailed(String message)
+	{
+		return new CommandLineEvent(Name.LoadInstanceFailed.name(), Optional.of(message));
+	}
+
+	/**
+	 * Creates an CommandLineEvent for InvalidArgument Event.
+	 *
+	 * @param message the message of the event
+	 * @return the CommandLineEvent created for InvalidArgument Event
+	 * @since 4.0
+	 */
+	public static CommandLineEvent invalidArgument(String message)
+	{
+		return new CommandLineEvent(CommandLineEvent.Name.InvalidArgument.name(), Optional.of(message));
+	}
+
+}

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/Event.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/Event.java
@@ -1,0 +1,72 @@
+// Wildebeest Migration Framework
+// Copyright © 2013 - 2018, Matheson Ventures Pte Ltd
+//
+// This file is part of Wildebeest
+//
+// Wildebeest is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License v2 as published by the Free
+// Software Foundation.
+//
+// Wildebeest is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Wildebeest.  If not, see http://www.gnu.org/licenses/gpl-2.0.html
+
+package co.mv.wb.event;
+
+import co.mv.wb.framework.ArgumentNullException;
+
+import java.util.Optional;
+
+/**
+ * Defines an Event
+ *
+ * @since 4.0
+ */
+public class Event
+{
+	private final String name;
+	private final Optional<String> message;
+
+	/**
+	 * Constructs a new Event with the supplied details.
+	 *
+	 * @param name    the name of the event, this should be supplied from Event
+	 * @param message a message of the event
+	 * @since 4.0
+	 */
+	public Event(
+		String name,
+		Optional<String> message)
+	{
+		if (name == null) throw new ArgumentNullException("name");
+		if (message == null) throw new ArgumentNullException("message");
+
+		this.name = name;
+		this.message = message;
+	}
+
+	/**
+	 * Gets the name of the event
+	 *
+	 * @return the name of the event
+	 * @since 4.0
+	 */
+	public String getName()
+	{
+		return this.name;
+	}
+
+	/**
+	 * Gets the message of the event
+	 *
+	 * @return the name of the event
+	 * @since 4.0
+	 */
+	public Optional<String> getMessage()
+	{
+		return this.message;
+	}
+}

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/EventSink.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/EventSink.java
@@ -1,0 +1,33 @@
+// Wildebeest Migration Framework
+// Copyright © 2013 - 2018, Matheson Ventures Pte Ltd
+//
+// This file is part of Wildebeest
+//
+// Wildebeest is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License v2 as published by the Free
+// Software Foundation.
+//
+// Wildebeest is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Wildebeest.  If not, see http://www.gnu.org/licenses/gpl-2.0.html
+
+package co.mv.wb.event;
+
+/**
+ * An EventSink is used to accept events to be processed
+ *
+ * @since 4.0
+ */
+public interface EventSink
+{
+	/**
+	 *
+	 *
+	 * @param event Event to be processed
+	 * @since 4.0
+	 */
+	void onEvent(Event event);
+}

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/JumpStateEvent.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/JumpStateEvent.java
@@ -1,0 +1,64 @@
+package co.mv.wb.event;
+
+import java.util.Optional;
+
+public class JumpStateEvent extends Event
+{
+	/**
+	 * Provides all events associated with JumpState Event.
+	 *
+	 * @since 4.0
+	 */
+	public enum Name
+	{
+		Start, Complete, Failed;
+	}
+
+	/**
+	 * Constructs a new Event with the supplied details.
+	 *
+	 * @param name    the name of the event, this should be supplied from Event
+	 * @param message a message of the event
+	 * @since 4.0
+	 */
+	public JumpStateEvent(
+		String name,
+		Optional<String> message)
+	{
+		super(name, message);
+	}
+
+	/**
+	 * Creates an JumpStateEvent for Start Event.
+	 *
+	 * @return the JumpStateEvent created for Start Event
+	 * @since 4.0
+	 */
+	public static JumpStateEvent start(Optional<String> message)
+	{
+		return new JumpStateEvent(Name.Start.name(), message);
+	}
+
+	/**
+	 * Creates an JumpStateEvent for Complete Event.
+	 *
+	 * @return the JumpStateEvent created for Complete Event
+	 * @since 4.0
+	 */
+	public static JumpStateEvent complete(Optional<String> message)
+	{
+		return new JumpStateEvent(Name.Complete.name(), message);
+	}
+
+	/**
+	 * Creates an JumpStateEvent for Failed Event.
+	 *
+	 * @param message the message of the event
+	 * @return the JumpStateEvent created for Failed Event
+	 * @since 4.0
+	 */
+	public static JumpStateEvent failed(String message)
+	{
+		return new JumpStateEvent(Name.Failed.name(), Optional.of(message));
+	}
+}

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/MigrationEvent.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/MigrationEvent.java
@@ -1,0 +1,87 @@
+// Wildebeest Migration Framework
+// Copyright © 2013 - 2018, Matheson Ventures Pte Ltd
+//
+// This file is part of Wildebeest
+//
+// Wildebeest is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License v2 as published by the Free
+// Software Foundation.
+//
+// Wildebeest is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Wildebeest.  If not, see http://www.gnu.org/licenses/gpl-2.0.html
+
+package co.mv.wb.event;
+
+import java.util.Optional;
+
+/**
+ * Defines an event for Migration
+ *
+ * @since 4.0
+ */
+public class MigrationEvent extends Event
+{
+	/**
+	 * Provides all events associated with Migration.
+	 *
+	 * @since 4.0
+	 */
+	public enum Name
+	{
+		Start, Complete, Failed;
+	}
+
+	/**
+	 * Constructs a new MigrationEvent with the supplied details.
+	 *
+	 * @param name    the name of the event
+	 * @param message the message of the event
+	 * @since 4.0
+	 */
+	public MigrationEvent(
+		String name,
+		Optional<String> message)
+	{
+		super(name, message);
+	}
+
+	/**
+	 * Creates an MigrationEvent for Start Event.
+	 *
+	 * @param message the message of the event
+	 * @return the MigrationEvent created for Start Event
+	 * @since 4.0
+	 */
+	public static MigrationEvent start(Optional<String> message)
+	{
+		return new MigrationEvent(MigrationEvent.Name.Start.name(), message);
+	}
+
+	/**
+	 * Creates an MigrationEvent for Complete Event.
+	 *
+	 * @param message the message of the event
+	 * @return the MigrationEvent created for Complete Event
+	 * @since 4.0
+	 */
+	public static MigrationEvent complete(Optional<String> message)
+	{
+		return new MigrationEvent(MigrationEvent.Name.Complete.name(), message);
+	}
+
+	/**
+	 * Creates an MigrationEvent for Failed Event.
+	 *
+	 * @param message the message of the event
+	 * @return the MigrationEvent created for Failed Event
+	 * @since 4.0
+	 */
+	public static MigrationEvent failed(String message)
+	{
+		return new MigrationEvent(MigrationEvent.Name.Failed.name(), Optional.of(message));
+	}
+}

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/StateEvent.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/StateEvent.java
@@ -1,0 +1,119 @@
+// Wildebeest Migration Framework
+// Copyright © 2013 - 2018, Matheson Ventures Pte Ltd
+//
+// This file is part of Wildebeest
+//
+// Wildebeest is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License v2 as published by the Free
+// Software Foundation.
+//
+// Wildebeest is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Wildebeest.  If not, see http://www.gnu.org/licenses/gpl-2.0.html
+
+package co.mv.wb.event;
+
+import java.util.Optional;
+
+/**
+ * Defines an event for State
+ *
+ * @since 4.0
+ */
+public class StateEvent extends Event
+{
+	/**
+	 * Provides all events associated with State.
+	 *
+	 * @since 4.0
+	 */
+	public enum Name
+	{
+		PreAssert, PostAssert, AssertionStart, AssertionComplete, ChangeSuccess, ChangeFailed;
+	}
+
+	/**
+	 * Constructs a new StateEvent with the supplied details.
+	 *
+	 * @param name    the name of the event
+	 * @param message the message of the event
+	 * @since 4.0
+	 */
+	public StateEvent(
+		String name,
+		Optional<String> message)
+	{
+		super(name, message);
+	}
+
+	/**
+	 * Creates an StateEvent for PreAssert Event.
+	 *
+	 * @param message the message of the event
+	 * @return the StateEvent created for PreAssert Event
+	 * @since 4.0
+	 */
+	public static StateEvent preAssert(String message)
+	{
+		return new StateEvent(StateEvent.Name.PreAssert.name(), Optional.of(message));
+	}
+
+	/**
+	 * Creates an StateEvent for PostAssert Event.
+	 *
+	 * @param message the message of the event
+	 * @return the StateEvent created for PreAssert Event
+	 * @since 4.0
+	 */
+	public static StateEvent postAssert(Optional<String> message)
+	{
+		return new StateEvent(StateEvent.Name.PostAssert.name(), message);
+	}
+
+	/**
+	 * Creates an StateEvent for AssertionStart Event.
+	 *
+	 * @return the StateEvent created for AssertionStart Event
+	 * @since 4.0
+	 */
+	public static Event assertionStart(Optional<String> message)
+	{
+		return new StateEvent(Name.AssertionStart.name(), message);
+	}
+
+	/**
+	 * Creates an StateEvent for AssertionComplete Event.
+	 *
+	 * @return the StateEvent created for AssertionComplete Event
+	 * @since 4.0
+	 */
+	public static Event assertionComplete(Optional<String> message)
+	{
+		return new StateEvent(Name.AssertionComplete.name(), message);
+	}
+
+	/**
+	 * Creates an StateEvent for ChangeSuccess Event.
+	 *
+	 * @return the StateEvent created for ChangeSuccess Event
+	 * @since 4.0
+	 */
+	public static Event changeSuccess(Optional<String> message)
+	{
+		return new StateEvent(Name.ChangeSuccess.name(), message);
+	}
+
+	/**
+	 * Creates an StateEvent for ChangeFailed Event.
+	 *
+	 * @return the StateEvent created for ChangeFailed Event
+	 * @since 4.0
+	 */
+	public static Event changeFailed(String message)
+	{
+		return new StateEvent(Name.ChangeFailed.name(), Optional.of(message));
+	}
+}

--- a/MV.Wildebeest.Core/MV.Wildebeest.Core.iml
+++ b/MV.Wildebeest.Core/MV.Wildebeest.Core.iml
@@ -45,15 +45,6 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/target/core/libcompile/slf4j-api-1.7.5.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
           <root url="jar://$MODULE_DIR$/target/core/libcompile/reflections-0.9.11.jar!/" />
         </CLASSES>
         <JAVADOC />
@@ -165,6 +156,15 @@
       <library>
         <CLASSES>
           <root url="jar://$MODULE_DIR$/target/core/libcompile/log4j-1.2.17.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/target/core/libcompile/slf4j-api-1.7.7.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/MV.Wildebeest.Core/source/core/classtree/log4j.xml
+++ b/MV.Wildebeest.Core/source/core/classtree/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="true">
-	<!-- Console1 Appender -->
+	<!-- Console Appender -->
 	<appender name="console" class="org.apache.log4j.ConsoleAppender">
 		<param name="Target" value="System.out"/>
 		<layout class="org.apache.log4j.PatternLayout">
@@ -13,6 +13,14 @@
 			<param name="AcceptOnMatch" value="true"/>
 		</filter>
 	</appender>
+
+	<appender name="wildebeest-command-log" class="org.apache.log4j.ConsoleAppender">
+		<param name="Target" value="System.out" />
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%m%n" />
+		</layout>
+	</appender>
+
 	<!-- Error Log File Appender -->
 	<appender name="wildebeest-log" class="org.apache.log4j.FileAppender">
 		<param name="Append" value="true"/>
@@ -26,6 +34,12 @@
 			<param name="AcceptOnMatch" value="true"/>
 		</filter>
 	</appender>
+
+	<logger name="wildebeestCommandLogger">
+		<level value="info"/>
+		<appender-ref ref="wildebeest-command-log" />
+	</logger>
+
 	<root>
 		<appender-ref ref="console"/>
 		<appender-ref ref="wildebeest-log"/>

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/Wildebeest.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/Wildebeest.java
@@ -16,6 +16,7 @@
 
 package co.mv.wb;
 
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.framework.Util;
 import co.mv.wb.impl.WildebeestApiBuilder;
@@ -34,7 +35,6 @@ import co.mv.wb.plugin.sqlserver.SqlServerDropDatabaseMigrationPlugin;
 import co.mv.wb.plugin.sqlserver.SqlServerDropSchemaMigrationPlugin;
 import org.reflections.Reflections;
 
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -165,11 +165,11 @@ public class Wildebeest
 	//
 
 	public static WildebeestApiBuilder wildebeestApi(
-		PrintStream output)
+		EventSink eventSink)
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 
-		return WildebeestApiBuilder.create(output);
+		return WildebeestApiBuilder.create(eventSink);
 	}
 
 	//

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/WildebeestApi.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/WildebeestApi.java
@@ -71,12 +71,14 @@ public interface WildebeestApi
 	 * that were generated for the Assertions for this Resource's current
 	 * state.
 	 * @throws IndeterminateStateException when the current state of the resource cannot be determined clearly.
+	 * @throws AssertionFailedException    if one or more assertions of the current state fails
 	 * @since 1.0
 	 */
 	List<AssertionResult> assertState(
 		Resource resource,
 		Instance instance) throws
-		IndeterminateStateException;
+		IndeterminateStateException,
+		AssertionFailedException;
 
 	/**
 	 * Checks the state of an instance of a resource.
@@ -84,12 +86,14 @@ public interface WildebeestApi
 	 * @param resource the descriptor file for the resource.
 	 * @param instance the descriptor file for the instance.
 	 * @throws IndeterminateStateException if the current state of the resource cannot be determined.
+	 * @throws AssertionFailedException    if one or more assertions of the current state fails
 	 * @since 1.0
 	 */
 	void state(
 		Resource resource,
 		Instance instance) throws
-		IndeterminateStateException;
+		IndeterminateStateException,
+		AssertionFailedException;
 
 	/**
 	 * Migrates an instance of a resource to a particular state.

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/impl/WildebeestApiBuilder.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/impl/WildebeestApiBuilder.java
@@ -23,9 +23,9 @@ import co.mv.wb.ResourcePlugin;
 import co.mv.wb.ResourceType;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -47,17 +47,17 @@ public class WildebeestApiBuilder
 	/**
 	 * Creates a new WildebeestApiBuilder with the specified PrintStream for Wildebeest to output to.
 	 *
-	 * @param output the PrintStream that Wildebeest should output to.
+	 * @param eventSink the EventSink that Wildebeest should output to.
 	 * @return a new WildebeestApiBuilder.
 	 * @since 4.0
 	 */
 	public static WildebeestApiBuilder create(
-		PrintStream output)
+		EventSink eventSink)
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 
 		return new WildebeestApiBuilder(
-			new WildebeestApiImpl(output),
+			new WildebeestApiImpl(eventSink),
 			new ArrayList<>(),
 			new HashMap<>(),
 			new HashMap<>());

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/base/BaseMigration.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/base/BaseMigration.java
@@ -19,7 +19,9 @@ package co.mv.wb.plugin.base;
 import co.mv.wb.Migration;
 import co.mv.wb.framework.ArgumentNullException;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 /**

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/base/ImmutableState.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/base/ImmutableState.java
@@ -23,6 +23,7 @@ import co.mv.wb.framework.ArgumentNullException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -189,4 +190,5 @@ public class ImmutableState implements State
 	{
 		return this.description;
 	}
+
 }

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/composite/ExternalResourceMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/composite/ExternalResourceMigrationPlugin.java
@@ -36,10 +36,10 @@ import co.mv.wb.TargetNotSpecifiedException;
 import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.WildebeestApi;
 import co.mv.wb.XmlValidationException;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 
 import java.io.File;
-import java.io.PrintStream;
 
 /**
  * The {@link MigrationPlugin} for {@link ExternalResourceMigration}'s.
@@ -68,12 +68,12 @@ public class ExternalResourceMigrationPlugin implements MigrationPlugin
 	}
 
 	@Override public void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (migration == null) throw new ArgumentNullException("migration");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/AnsiSqlCreateDatabaseMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/AnsiSqlCreateDatabaseMigrationPlugin.java
@@ -23,10 +23,12 @@ import co.mv.wb.MigrationFaultException;
 import co.mv.wb.MigrationPlugin;
 import co.mv.wb.MigrationPluginType;
 import co.mv.wb.ModelExtensions;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.framework.DatabaseHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.PrintStream;
 import java.sql.SQLException;
 
 /**
@@ -37,13 +39,15 @@ import java.sql.SQLException;
 @MigrationPluginType(uri = "co.mv.wb.generaldatabase:AnsiSqlCreateDatabase")
 public class AnsiSqlCreateDatabaseMigrationPlugin implements MigrationPlugin
 {
+	private static final Logger LOG = LoggerFactory.getLogger(AnsiSqlCreateDatabaseMigrationPlugin.class);
+
 	@Override public void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (migration == null) throw new ArgumentNullException("migration");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/AnsiSqlDropDatabaseMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/AnsiSqlDropDatabaseMigrationPlugin.java
@@ -23,10 +23,10 @@ import co.mv.wb.MigrationFaultException;
 import co.mv.wb.MigrationPlugin;
 import co.mv.wb.MigrationPluginType;
 import co.mv.wb.ModelExtensions;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.framework.DatabaseHelper;
 
-import java.io.PrintStream;
 import java.sql.SQLException;
 
 /**
@@ -38,12 +38,12 @@ import java.sql.SQLException;
 public class AnsiSqlDropDatabaseMigrationPlugin implements MigrationPlugin
 {
 	@Override public void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (migration == null) throw new ArgumentNullException("migration");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/SqlScriptMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/generaldatabase/SqlScriptMigrationPlugin.java
@@ -23,10 +23,10 @@ import co.mv.wb.MigrationFaultException;
 import co.mv.wb.MigrationPlugin;
 import co.mv.wb.MigrationPluginType;
 import co.mv.wb.ModelExtensions;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.framework.DatabaseHelper;
 
-import java.io.PrintStream;
 import java.sql.SQLException;
 
 /**
@@ -38,12 +38,12 @@ import java.sql.SQLException;
 public class SqlScriptMigrationPlugin implements MigrationPlugin
 {
 	@Override public void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (migration == null) throw new ArgumentNullException("migration");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/mysql/MySqlCreateDatabaseMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/mysql/MySqlCreateDatabaseMigrationPlugin.java
@@ -23,10 +23,10 @@ import co.mv.wb.MigrationFaultException;
 import co.mv.wb.MigrationPlugin;
 import co.mv.wb.MigrationPluginType;
 import co.mv.wb.ModelExtensions;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.framework.DatabaseHelper;
 
-import java.io.PrintStream;
 import java.sql.SQLException;
 
 /**
@@ -38,12 +38,12 @@ import java.sql.SQLException;
 public class MySqlCreateDatabaseMigrationPlugin implements MigrationPlugin
 {
 	@Override public void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (migration == null) throw new ArgumentNullException("migration");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/mysql/MySqlDatabaseResourcePlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/mysql/MySqlDatabaseResourcePlugin.java
@@ -24,10 +24,10 @@ import co.mv.wb.Resource;
 import co.mv.wb.ResourcePlugin;
 import co.mv.wb.State;
 import co.mv.wb.Wildebeest;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.plugin.generaldatabase.Extensions;
 
-import java.io.PrintStream;
 import java.sql.SQLException;
 import java.util.UUID;
 
@@ -89,12 +89,12 @@ public class MySqlDatabaseResourcePlugin implements ResourcePlugin
 
 	@Override
 	public void setStateId(
-		PrintStream output,
+		EventSink eventSink,
 		Resource resource,
 		Instance instance,
 		UUID stateId)
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (resource == null) throw new ArgumentNullException("resource");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/mysql/MySqlDropDatabaseMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/mysql/MySqlDropDatabaseMigrationPlugin.java
@@ -23,10 +23,10 @@ import co.mv.wb.MigrationFaultException;
 import co.mv.wb.MigrationPlugin;
 import co.mv.wb.MigrationPluginType;
 import co.mv.wb.ModelExtensions;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.framework.DatabaseHelper;
 
-import java.io.PrintStream;
 import java.sql.SQLException;
 
 /**
@@ -38,12 +38,12 @@ import java.sql.SQLException;
 public class MySqlDropDatabaseMigrationPlugin implements MigrationPlugin
 {
 	@Override public void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (migration == null) throw new ArgumentNullException("migration");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/postgresql/PostgreSqlDatabaseResourcePlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/postgresql/PostgreSqlDatabaseResourcePlugin.java
@@ -24,11 +24,11 @@ import co.mv.wb.Resource;
 import co.mv.wb.ResourcePlugin;
 import co.mv.wb.State;
 import co.mv.wb.Wildebeest;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.plugin.generaldatabase.AnsiSqlDatabaseInstance;
 import co.mv.wb.plugin.generaldatabase.Extensions;
 
-import java.io.PrintStream;
 import java.sql.SQLException;
 import java.util.UUID;
 
@@ -93,12 +93,12 @@ public class PostgreSqlDatabaseResourcePlugin implements ResourcePlugin
 
 	@Override
 	public void setStateId(
-		PrintStream output,
+		EventSink eventSink,
 		Resource resource,
 		Instance instance,
 		UUID stateId)
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (resource == null) throw new ArgumentNullException("resource");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/sqlserver/SqlServerCreateDatabaseMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/sqlserver/SqlServerCreateDatabaseMigrationPlugin.java
@@ -23,11 +23,11 @@ import co.mv.wb.MigrationFaultException;
 import co.mv.wb.MigrationPlugin;
 import co.mv.wb.MigrationPluginType;
 import co.mv.wb.ModelExtensions;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.framework.DatabaseHelper;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
 
-import java.io.PrintStream;
 import java.sql.SQLException;
 
 /**
@@ -39,12 +39,12 @@ import java.sql.SQLException;
 public class SqlServerCreateDatabaseMigrationPlugin implements MigrationPlugin
 {
 	@Override public void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (migration == null) throw new ArgumentNullException("migration");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/sqlserver/SqlServerCreateSchemaMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/sqlserver/SqlServerCreateSchemaMigrationPlugin.java
@@ -23,11 +23,11 @@ import co.mv.wb.MigrationFaultException;
 import co.mv.wb.MigrationPlugin;
 import co.mv.wb.MigrationPluginType;
 import co.mv.wb.ModelExtensions;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.framework.DatabaseHelper;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
 
-import java.io.PrintStream;
 import java.sql.SQLException;
 
 /**
@@ -39,12 +39,12 @@ import java.sql.SQLException;
 public class SqlServerCreateSchemaMigrationPlugin implements MigrationPlugin
 {
 	@Override public void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (migration == null) throw new ArgumentNullException("migration");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/sqlserver/SqlServerDatabaseResourcePlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/sqlserver/SqlServerDatabaseResourcePlugin.java
@@ -24,10 +24,10 @@ import co.mv.wb.Resource;
 import co.mv.wb.ResourcePlugin;
 import co.mv.wb.State;
 import co.mv.wb.Wildebeest;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.plugin.generaldatabase.Extensions;
 
-import java.io.PrintStream;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -94,12 +94,12 @@ public class SqlServerDatabaseResourcePlugin implements ResourcePlugin
 
 	@Override
 	public void setStateId(
-		PrintStream output,
+		EventSink eventSink,
 		Resource resource,
 		Instance instance,
 		UUID stateId)
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (resource == null) throw new ArgumentNullException("resource");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/sqlserver/SqlServerDropDatabaseMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/sqlserver/SqlServerDropDatabaseMigrationPlugin.java
@@ -23,11 +23,11 @@ import co.mv.wb.MigrationFaultException;
 import co.mv.wb.MigrationPlugin;
 import co.mv.wb.MigrationPluginType;
 import co.mv.wb.ModelExtensions;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.framework.DatabaseHelper;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
 
-import java.io.PrintStream;
 import java.sql.SQLException;
 
 /**
@@ -39,12 +39,12 @@ import java.sql.SQLException;
 public class SqlServerDropDatabaseMigrationPlugin implements MigrationPlugin
 {
 	@Override public void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (migration == null) throw new ArgumentNullException("migration");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/sqlserver/SqlServerDropSchemaMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/plugin/sqlserver/SqlServerDropSchemaMigrationPlugin.java
@@ -23,11 +23,11 @@ import co.mv.wb.MigrationFaultException;
 import co.mv.wb.MigrationPlugin;
 import co.mv.wb.MigrationPluginType;
 import co.mv.wb.ModelExtensions;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.framework.DatabaseHelper;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
 
-import java.io.PrintStream;
 import java.sql.SQLException;
 
 /**
@@ -39,12 +39,12 @@ import java.sql.SQLException;
 public class SqlServerDropSchemaMigrationPlugin implements MigrationPlugin
 {
 	@Override public void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (migration == null) throw new ArgumentNullException("migration");
 		if (instance == null) throw new ArgumentNullException("instance");
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/cli/WildebeestCommandIntegrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/cli/WildebeestCommandIntegrationTests.java
@@ -23,6 +23,7 @@ import co.mv.wb.PluginBuildException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
 import co.mv.wb.XmlValidationException;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.DatabaseHelper;
 import co.mv.wb.plugin.mysql.MySqlDatabaseInstance;
 import co.mv.wb.plugin.mysql.MySqlUtil;
@@ -30,6 +31,8 @@ import co.mv.wb.plugin.postgresql.PostgreSqlDatabaseInstance;
 import co.mv.wb.plugin.sqlserver.SqlServerDatabaseInstance;
 import co.mv.wb.plugin.sqlserver.SqlServerUtil;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.PrintStream;
@@ -42,7 +45,7 @@ import java.sql.SQLException;
  */
 public class WildebeestCommandIntegrationTests
 {
-
+	private static final Logger LOG = LoggerFactory.getLogger("wildebeestCommandLogger");
 	//
 	// MySql
 	//
@@ -55,15 +58,14 @@ public class WildebeestCommandIntegrationTests
 		XmlValidationException
 	{
 		// Setup
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
 		WildebeestCommand wb = new WildebeestCommand(
-			output,
+			eventSink,
 			wildebeestApi);
 
 		String[] args = new String[]
@@ -102,15 +104,15 @@ public class WildebeestCommandIntegrationTests
 		XmlValidationException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
 		WildebeestCommand wb = new WildebeestCommand(
-			output,
+			eventSink,
 			wildebeestApi);
 
 		MySqlDatabaseInstance instanceT = null;
@@ -161,15 +163,14 @@ public class WildebeestCommandIntegrationTests
 		XmlValidationException
 	{
 		// Setup
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
 		WildebeestCommand wb = new WildebeestCommand(
-			output,
+			eventSink,
 			wildebeestApi);
 
 		Instance instance = null;
@@ -207,15 +208,15 @@ public class WildebeestCommandIntegrationTests
 	@Test public void mySqlDatabaseMigrateToInvalidStateName()
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
 		WildebeestCommand wb = new WildebeestCommand(
-			output,
+			eventSink,
 			wildebeestApi);
 
 		// Execute
@@ -240,15 +241,15 @@ public class WildebeestCommandIntegrationTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
 		WildebeestCommand wb = new WildebeestCommand(
-			output,
+			eventSink,
 			wildebeestApi);
 
 		//
@@ -285,15 +286,14 @@ public class WildebeestCommandIntegrationTests
 		XmlValidationException
 	{
 		// Setup
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
 		WildebeestCommand wb = new WildebeestCommand(
-			output,
+			eventSink,
 			wildebeestApi);
 
 		String[] args = new String[]
@@ -334,15 +334,15 @@ public class WildebeestCommandIntegrationTests
 		XmlValidationException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
 		WildebeestCommand wb = new WildebeestCommand(
-			output,
+			eventSink,
 			wildebeestApi);
 
 		String[] args = new String[]

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/cli/WildebeestCommandUnitTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/cli/WildebeestCommandUnitTests.java
@@ -31,12 +31,15 @@ import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
 import co.mv.wb.XmlValidationException;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.fixture.Fixtures;
 import co.mv.wb.fixture.TestContext_WildebeestCommandUnit;
 import co.mv.wb.framework.PredicateMatcher;
 import co.mv.wb.plugin.fake.FakeConstants;
 import org.junit.Test;
 import org.mockito.Matchers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -54,6 +57,8 @@ import static org.mockito.Mockito.verifyZeroInteractions;
  */
 public class WildebeestCommandUnitTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger("wildebeestCommandLogger");
+
 	@Test public void noCommand_noOperationsCalled()
 	{
 		// Setup
@@ -136,14 +141,14 @@ public class WildebeestCommandUnitTests
 	@Test public void migrate_missingInstanceArg_fails()
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Fixtures
 			.wildebeestApi()
 			.get();
 
 		WildebeestCommand wb = new WildebeestCommand(
-			output,
+			eventSink,
 			wildebeestApi);
 
 		// Execute
@@ -161,14 +166,14 @@ public class WildebeestCommandUnitTests
 	@Test public void migrate_missingResourceArg_fails()
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Fixtures
 			.wildebeestApi()
 			.get();
 
 		WildebeestCommand wb = new WildebeestCommand(
-			output,
+			eventSink,
 			wildebeestApi);
 
 		// Execute
@@ -186,15 +191,15 @@ public class WildebeestCommandUnitTests
 	@Test public void plugins_succeeds()
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
 		WildebeestCommand wb = new WildebeestCommand(
-			output,
+			eventSink,
 			wildebeestApi);
 
 		// Execute

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/fixture/TestContext_WildebeestCommandUnit.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/fixture/TestContext_WildebeestCommandUnit.java
@@ -4,6 +4,9 @@ import co.mv.wb.Instance;
 import co.mv.wb.Resource;
 import co.mv.wb.WildebeestApi;
 import co.mv.wb.cli.WildebeestCommand;
+import co.mv.wb.event.EventSink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 
@@ -15,11 +18,12 @@ import java.io.PrintStream;
  */
 public class TestContext_WildebeestCommandUnit
 {
-	public final PrintStream output;
+	public final EventSink eventSink;
 	public final Resource fakeResource;
 	public final Instance fakeInstance;
 	public final WildebeestApi wildebeestApi;
 	public final WildebeestCommand wildebeestCommand;
+	private static final Logger LOG = LoggerFactory.getLogger("wildebeestCommandLogger");
 
 	public static TestContext_WildebeestCommandUnit get()
 	{
@@ -28,7 +32,7 @@ public class TestContext_WildebeestCommandUnit
 
 	private TestContext_WildebeestCommandUnit()
 	{
-		this.output = System.out;
+		this.eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		this.fakeResource = Fixtures.fakeResource();
 		this.fakeInstance = Fixtures.fakeInstance();
@@ -40,7 +44,7 @@ public class TestContext_WildebeestCommandUnit
 			.get();
 
 		this.wildebeestCommand = new WildebeestCommand(
-			output,
+			eventSink,
 			wildebeestApi);
 	}
 }

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplAssertStateIntegrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplAssertStateIntegrationTests.java
@@ -17,6 +17,7 @@
 package co.mv.wb.impl;
 
 import co.mv.wb.Assertion;
+import co.mv.wb.AssertionFailedException;
 import co.mv.wb.AssertionResult;
 import co.mv.wb.Asserts;
 import co.mv.wb.IndeterminateStateException;
@@ -25,6 +26,8 @@ import co.mv.wb.Resource;
 import co.mv.wb.State;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
+import co.mv.wb.event.Event;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.base.ImmutableState;
 import co.mv.wb.plugin.base.ResourceImpl;
 import co.mv.wb.plugin.fake.FakeConstants;
@@ -33,6 +36,8 @@ import co.mv.wb.plugin.fake.FakeResourcePlugin;
 import co.mv.wb.plugin.fake.TagAssertion;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -50,12 +55,15 @@ import static org.junit.Assert.assertNotNull;
  */
 public class WildebeestApiImplAssertStateIntegrationTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(WildebeestApiImplAssertStateIntegrationTests.class);
+
 	@Test
-	public void assertState_noAssertions_succeeds() throws IndeterminateStateException
+	public void assertState_noAssertions_succeeds() throws
+		IndeterminateStateException,
+		AssertionFailedException
 	{
 		// Setup
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if (event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		Resource resource = new ResourceImpl(
 			UUID.randomUUID(),
 			FakeConstants.Fake,
@@ -68,7 +76,7 @@ public class WildebeestApiImplAssertStateIntegrationTests
 		FakeInstance instance = new FakeInstance(state.getStateId());
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withResourcePlugin(FakeConstants.Fake, new FakeResourcePlugin())
 			.get();
 
@@ -83,9 +91,12 @@ public class WildebeestApiImplAssertStateIntegrationTests
 	}
 
 	@Test
-	public void assertState_oneAssertion_succeeds() throws IndeterminateStateException
+	public void assertState_oneAssertion_succeeds() throws
+		IndeterminateStateException,
+		AssertionFailedException
 	{
 		// Setup
+		EventSink eventSink = (event) -> {if (event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		Resource resource = new ResourceImpl(
 			UUID.randomUUID(),
 			FakeConstants.Fake,
@@ -105,7 +116,7 @@ public class WildebeestApiImplAssertStateIntegrationTests
 		instance.setTag("Foo");
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(System.out)
+			.wildebeestApi(eventSink)
 			.withResourcePlugin(FakeConstants.Fake, new FakeResourcePlugin())
 			.get();
 
@@ -126,10 +137,12 @@ public class WildebeestApiImplAssertStateIntegrationTests
 	}
 
 	@Test
-	public void assertState_multipleAssertions_succeeds() throws IndeterminateStateException
+	public void assertState_multipleAssertions_succeeds() throws
+		IndeterminateStateException,
+		AssertionFailedException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if (event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		FakeResourcePlugin resourcePlugin = new FakeResourcePlugin();
 		Resource resource = new ResourceImpl(
 			UUID.randomUUID(),
@@ -156,7 +169,7 @@ public class WildebeestApiImplAssertStateIntegrationTests
 		instance.setTag("Foo");
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withResourcePlugin(FakeConstants.Fake, resourcePlugin)
 			.get();
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplJumpStateIntegrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplJumpStateIntegrationTests.java
@@ -27,6 +27,7 @@ import co.mv.wb.State;
 import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.base.ImmutableState;
 import co.mv.wb.plugin.base.ResourceImpl;
 import co.mv.wb.plugin.fake.FakeConstants;
@@ -34,6 +35,8 @@ import co.mv.wb.plugin.fake.FakeInstance;
 import co.mv.wb.plugin.fake.FakeResourcePlugin;
 import co.mv.wb.plugin.fake.TagAssertion;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -49,6 +52,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class WildebeestApiImplJumpStateIntegrationTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(WildebeestApiImplJumpStateIntegrationTests.class);
+
 	@Test
 	public void jumpstate_assertionFail_throws()
 	{
@@ -57,7 +62,7 @@ public class WildebeestApiImplJumpStateIntegrationTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		// Resource
 		FakeResourcePlugin resourcePlugin = new FakeResourcePlugin();
@@ -78,7 +83,7 @@ public class WildebeestApiImplJumpStateIntegrationTests
 		instance.setTag("Bar");
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -118,7 +123,7 @@ public class WildebeestApiImplJumpStateIntegrationTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		// Resource
 		FakeResourcePlugin resourcePlugin = new FakeResourcePlugin();
@@ -135,7 +140,7 @@ public class WildebeestApiImplJumpStateIntegrationTests
 		final UUID targetStateId = UUID.randomUUID();
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -176,10 +181,10 @@ public class WildebeestApiImplJumpStateIntegrationTests
 	{
 
 		//
-		// Setup
+		//Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		// Resource
 		Resource resource = new ResourceImpl(
@@ -199,7 +204,7 @@ public class WildebeestApiImplJumpStateIntegrationTests
 		instance.setTag("Foo");
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplMigrateIntegrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplMigrateIntegrationTests.java
@@ -31,6 +31,7 @@ import co.mv.wb.TargetNotSpecifiedException;
 import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.base.ImmutableState;
 import co.mv.wb.plugin.base.ResourceImpl;
 import co.mv.wb.plugin.fake.FakeConstants;
@@ -41,6 +42,8 @@ import co.mv.wb.plugin.fake.SetTagMigrationPlugin;
 import co.mv.wb.plugin.fake.TagAssertion;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.HashMap;
@@ -58,6 +61,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class WildebeestApiImplMigrateIntegrationTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(WildebeestApiImplMigrateUnitTests.class);
+
 	@Test
 	public void migrate_nonExistentToFirstState_succeeds() throws
 		AssertionFailedException,
@@ -70,7 +75,8 @@ public class WildebeestApiImplMigrateIntegrationTests
 		InvalidReferenceException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+
 		Resource resource = new ResourceImpl(
 			UUID.randomUUID(),
 			FakeConstants.Fake,
@@ -92,7 +98,7 @@ public class WildebeestApiImplMigrateIntegrationTests
 		FakeInstance instance = new FakeInstance();
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -123,7 +129,7 @@ public class WildebeestApiImplMigrateIntegrationTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		// The resource
 		Resource resource = new ResourceImpl(
@@ -179,7 +185,7 @@ public class WildebeestApiImplMigrateIntegrationTests
 		FakeInstance instance = new FakeInstance();
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -216,7 +222,7 @@ public class WildebeestApiImplMigrateIntegrationTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		// The resource
 		FakeResourcePlugin resourcePlugin = new FakeResourcePlugin();
@@ -308,7 +314,7 @@ public class WildebeestApiImplMigrateIntegrationTests
 		FakeInstance instance = new FakeInstance();
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -359,7 +365,7 @@ public class WildebeestApiImplMigrateIntegrationTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		// The resource
 		FakeResourcePlugin resourcePlugin = new FakeResourcePlugin();
@@ -391,7 +397,7 @@ public class WildebeestApiImplMigrateIntegrationTests
 		FakeInstance instance = new FakeInstance();
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -433,7 +439,7 @@ public class WildebeestApiImplMigrateIntegrationTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		// The resource
 		FakeResourcePlugin resourcePlugin = new FakeResourcePlugin();
@@ -465,7 +471,7 @@ public class WildebeestApiImplMigrateIntegrationTests
 		FakeInstance instance = new FakeInstance();
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -508,7 +514,7 @@ public class WildebeestApiImplMigrateIntegrationTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		// The resource
 		FakeResourcePlugin resourcePlugin = new FakeResourcePlugin();
@@ -540,7 +546,7 @@ public class WildebeestApiImplMigrateIntegrationTests
 		FakeInstance instance = new FakeInstance();
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplMigrateUnitTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplMigrateUnitTests.java
@@ -24,12 +24,12 @@ import co.mv.wb.InvalidReferenceException;
 import co.mv.wb.InvalidStateSpecifiedException;
 import co.mv.wb.MigrationFailedException;
 import co.mv.wb.MigrationNotPossibleException;
-import co.mv.wb.MigrationPlugin;
 import co.mv.wb.State;
 import co.mv.wb.TargetNotSpecifiedException;
 import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.fixture.TestContext_SimpleFakeResource;
 import co.mv.wb.fixture.TestContext_SimpleFakeResource_Builder;
 import co.mv.wb.plugin.fake.FakeConstants;
@@ -39,6 +39,8 @@ import co.mv.wb.plugin.fake.SetTagMigrationPlugin;
 import co.mv.wb.plugin.fake.TagAssertion;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -54,6 +56,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class WildebeestApiImplMigrateUnitTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(WildebeestApiImplMigrateUnitTests.class);
 	/**
 	 * A call to migrate specified a target and the resource does not have a default.  WildebeestApiImpl correctly
 	 * resolves the specified target and passes it to ResourceHelperImpl.
@@ -72,7 +75,7 @@ public class WildebeestApiImplMigrateUnitTests
 		InvalidReferenceException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		TestContext_SimpleFakeResource context = TestContext_SimpleFakeResource_Builder
 			.create()
@@ -80,7 +83,7 @@ public class WildebeestApiImplMigrateUnitTests
 			.getResourceWithNonExistantInitialState();
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withResourcePlugin(FakeConstants.Fake, new FakeResourcePlugin())
 			.withMigrationPlugin(new SetTagMigrationPlugin(context.resource))
 			.get();
@@ -121,10 +124,10 @@ public class WildebeestApiImplMigrateUnitTests
 			.withDefaultTarget("bar")
 			.getResourceWithNonExistantInitialState();
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withResourcePlugin(FakeConstants.Fake, new FakeResourcePlugin())
 			.withMigrationPlugin(new SetTagMigrationPlugin(context.resource))
 			.get();
@@ -149,21 +152,13 @@ public class WildebeestApiImplMigrateUnitTests
 	 * @since 4.0
 	 */
 	@Test
-	public void migrate_targetNotSpecifiedNoDefault_throws() throws
-		AssertionFailedException,
-		IndeterminateStateException,
-		InvalidStateSpecifiedException,
-		MigrationFailedException,
-		MigrationNotPossibleException,
-		TargetNotSpecifiedException,
-		UnknownStateSpecifiedException,
-		InvalidReferenceException
+	public void migrate_targetNotSpecifiedNoDefault_throws()
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withResourcePlugin(FakeConstants.Fake, new FakeResourcePlugin())
 			.get();
 
@@ -207,7 +202,7 @@ public class WildebeestApiImplMigrateUnitTests
 		InvalidReferenceException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		TestContext_SimpleFakeResource context = TestContext_SimpleFakeResource_Builder
 			.create()
@@ -215,7 +210,7 @@ public class WildebeestApiImplMigrateUnitTests
 			.getResourceWithNonExistantInitialState();
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withResourcePlugin(FakeConstants.Fake, new FakeResourcePlugin())
 			.withMigrationPlugin(new SetTagMigrationPlugin(context.resource))
 			.get();
@@ -250,7 +245,7 @@ public class WildebeestApiImplMigrateUnitTests
 		InvalidReferenceException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		TestContext_SimpleFakeResource context = TestContext_SimpleFakeResource_Builder
 			.create()
@@ -258,7 +253,7 @@ public class WildebeestApiImplMigrateUnitTests
 			.getResourceWithNonExistantInitialState();
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withResourcePlugin(FakeConstants.Fake, new FakeResourcePlugin())
 			.withMigrationPlugin(new SetTagMigrationPlugin(context.resource))
 			.get();
@@ -293,7 +288,7 @@ public class WildebeestApiImplMigrateUnitTests
 		InvalidReferenceException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		TestContext_SimpleFakeResource context = TestContext_SimpleFakeResource_Builder
 			.create()
@@ -308,7 +303,7 @@ public class WildebeestApiImplMigrateUnitTests
 		initialState.getAssertions().add(initialStateAssertion1);
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withResourcePlugin(FakeConstants.Fake, new FakeResourcePlugin())
 			.withMigrationPlugin(new SetTagMigrationPlugin(context.resource))
 			.get();
@@ -346,7 +341,7 @@ public class WildebeestApiImplMigrateUnitTests
 		InvalidReferenceException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		TestContext_SimpleFakeResource context = TestContext_SimpleFakeResource_Builder
 			.create()
@@ -361,7 +356,7 @@ public class WildebeestApiImplMigrateUnitTests
 		initialState.getAssertions().add(initialStateAssertion1);
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withResourcePlugin(FakeConstants.Fake, new FakeResourcePlugin())
 			.withMigrationPlugin(new SetTagMigrationPlugin(context.resource))
 			.get();

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/base/dom/DomResourceLoaderTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/base/dom/DomResourceLoaderTests.java
@@ -27,6 +27,8 @@ import co.mv.wb.PluginBuildException;
 import co.mv.wb.Resource;
 import co.mv.wb.WildebeestApi;
 import co.mv.wb.XmlValidationException;
+import co.mv.wb.event.Event;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.fixture.FixtureBuilder;
 import co.mv.wb.framework.ArgumentNullException;
 import co.mv.wb.impl.ResourceTypeServiceBuilder;
@@ -38,6 +40,8 @@ import co.mv.wb.plugin.fake.dom.DomSetTagMigrationBuilder;
 import co.mv.wb.plugin.fake.dom.DomTagAssertionBuilder;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.HashMap;
@@ -55,6 +59,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class DomResourceLoaderTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(DomResourceLoaderTests.class);
 	@Test
 	public void loadResource() throws
 		LoaderFault,
@@ -937,7 +942,8 @@ public class DomResourceLoaderTests
 		XmlValidationException
 	{
 		// Setup
-		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(System.out).get();
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(eventSink).get();
 		String resourceFilePath = "MySqlDatabase/database.wbresources.uses.assertionGroup.xml";
 
 		// Execute
@@ -977,7 +983,8 @@ public class DomResourceLoaderTests
 		XmlValidationException
 	{
 		// Setup
-		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(System.out).get();
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(eventSink).get();
 		String resourceFilePath = "PostgreSqlDatabase/database.wbresources.uses.assertionGroup.xml";
 
 		// Execute
@@ -1021,7 +1028,8 @@ public class DomResourceLoaderTests
 		XmlValidationException
 	{
 		// Setup
-		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(System.out).get();
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(eventSink).get();
 		String resourceFilePath = "SqlServerDatabase/database.wbresources.uses.assertionGroup.xml";
 
 		// Execute
@@ -1057,7 +1065,8 @@ public class DomResourceLoaderTests
 	public void loadResourceXml_assertionGroup_withInvalidXML_fails()
 	{
 		// Setup
-		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(System.out).get();
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(eventSink).get();
 		String resourceFilePath = "InvalidXml/InvalidSampleResourcesUsesAssertionGroup.xml";
 
 		new ExpectException(XmlValidationException.class)
@@ -1080,7 +1089,8 @@ public class DomResourceLoaderTests
 	public void loadResourceXml_assertionGroup_withInvalidRef_fails()
 	{
 		// Setup
-		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(System.out).get();
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(eventSink).get();
 		String resourceFilePath = "InvalidXml/InvalidReferenceSampleResourceUsesAssertionGroup.xml";
 
 		new ExpectException(InvalidReferenceException.class)
@@ -1211,7 +1221,8 @@ public class DomResourceLoaderTests
 	public void loadResourceXml_withInvalidXML_singleAssertion_fails()
 	{
 		// Setup
-		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(System.out).get();
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(eventSink).get();
 		String resourceFilePath = "InvalidXml/InvalidSampleResourceUsesSingleAssertRef.xml";
 
 		new ExpectException(XmlValidationException.class)
@@ -1234,7 +1245,8 @@ public class DomResourceLoaderTests
 	public void loadResourceXml_withInvalidRef_singleAssertion_fails()
 	{
 		// Setup
-		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(System.out).get();
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(eventSink).get();
 		String resourceFilePath = "InvalidXml/InvalidSampleResourceSingleAssertMissingRef.xml";
 
 		new ExpectException(InvalidReferenceException.class)
@@ -1262,7 +1274,8 @@ public class DomResourceLoaderTests
 		try
 		{
 			// Setup
-			WildebeestApi wildebeestApi = WildebeestApiBuilder.create(System.out).get();
+			EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+			WildebeestApi wildebeestApi = WildebeestApiBuilder.create(eventSink).get();
 			// Execute
 			return wildebeestApi.loadResource(new File(resourceFilePath));
 		}
@@ -1278,7 +1291,8 @@ public class DomResourceLoaderTests
 	public void loadResource_withMissingAssertionGroup_throwsXmlValidationException()
 	{
 		// Setup
-		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(System.out).get();
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+		WildebeestApi wildebeestApi = WildebeestApiBuilder.create(eventSink).get();
 		String resourceFilePath = "InvalidXml/InvalidSampleResourcesUsesAssertionGroup.xml";
 
 		// Execute and Verify

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/base/dom/ResourceLoaderIntegrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/base/dom/ResourceLoaderIntegrationTests.java
@@ -30,6 +30,8 @@ import co.mv.wb.TargetNotSpecifiedException;
 import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
+import co.mv.wb.event.Event;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.fixture.ProductCatalogueMySqlDatabaseResource;
 import co.mv.wb.impl.ResourceTypeServiceBuilder;
 import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
@@ -37,6 +39,8 @@ import co.mv.wb.plugin.mysql.MySqlDatabaseInstance;
 import co.mv.wb.plugin.mysql.MySqlProperties;
 import co.mv.wb.plugin.mysql.MySqlUtil;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.PrintStream;
@@ -48,6 +52,8 @@ import static org.junit.Assert.assertNotNull;
 
 public class ResourceLoaderIntegrationTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(ResourceLoaderIntegrationTests.class);
+
 	@Test
 	public void loadAndMigrateMySqlResourceFromXml() throws
 		AssertionFailedException,
@@ -67,7 +73,7 @@ public class ResourceLoaderIntegrationTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		ProductCatalogueMySqlDatabaseResource productCatalogueResource = new ProductCatalogueMySqlDatabaseResource();
 
@@ -89,7 +95,7 @@ public class ResourceLoaderIntegrationTests
 			null);
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/fake/FakeResourcePlugin.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/fake/FakeResourcePlugin.java
@@ -22,9 +22,9 @@ import co.mv.wb.Resource;
 import co.mv.wb.ResourcePlugin;
 import co.mv.wb.State;
 import co.mv.wb.Wildebeest;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 
-import java.io.PrintStream;
 import java.util.UUID;
 
 /**
@@ -54,12 +54,12 @@ public class FakeResourcePlugin implements ResourcePlugin
 
 	@Override
 	public void setStateId(
-		PrintStream output,
+		EventSink eventSink,
 		Resource resource,
 		Instance instance,
 		UUID stateId)
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (resource == null) throw new ArgumentNullException("resource");
 		if (instance == null) throw new ArgumentNullException("instance");
 		if (stateId == null) throw new ArgumentNullException("stateId");

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/fake/SetTagMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/fake/SetTagMigrationPlugin.java
@@ -24,9 +24,9 @@ import co.mv.wb.ModelExtensions;
 import co.mv.wb.Resource;
 import co.mv.wb.State;
 import co.mv.wb.Wildebeest;
+import co.mv.wb.event.EventSink;
+import co.mv.wb.event.MigrationEvent;
 import co.mv.wb.framework.ArgumentNullException;
-
-import java.io.PrintStream;
 
 /**
  * {@link MigrationPlugin} for the Fake plugin implementation.
@@ -47,24 +47,28 @@ public class SetTagMigrationPlugin implements MigrationPlugin
 
 	@Override
 	public void perform(
-		PrintStream output,
+		EventSink eventSink,
 		Migration migration,
 		Instance instance)
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (migration == null) throw new ArgumentNullException("migration");
 		if (instance == null) throw new ArgumentNullException("instance");
 
 		SetTagMigration migrationT = ModelExtensions.As(migration, SetTagMigration.class);
 		if (migrationT == null)
 		{
-			throw new IllegalArgumentException("migration must be a SetTagMigration");
+			String msg = "migration must be a SetTagMigration";
+			eventSink.onEvent(MigrationEvent.failed(msg));
+			throw new IllegalArgumentException(msg);
 		}
 
 		FakeInstance instanceT = ModelExtensions.As(instance, FakeInstance.class);
 		if (instanceT == null)
 		{
-			throw new IllegalArgumentException("instance must be a FakeInstance");
+			String msg = "instance must be a FakeInstance";
+			eventSink.onEvent(MigrationEvent.failed(msg));
+			throw new IllegalArgumentException(msg);
 		}
 
 		// TODO: These two lines should not be here because it should not be the resposibility of the migration plugin to update the tracked state of the instance.  Once MVWB-65 is done these can be removed and this class's private Resource field can be removed.

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/generaldatabase/BaseAnsiPluginUnitTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/generaldatabase/BaseAnsiPluginUnitTests.java
@@ -20,6 +20,7 @@ import co.mv.wb.AssertionResponse;
 import co.mv.wb.Migration;
 import co.mv.wb.MigrationFailedException;
 import co.mv.wb.MigrationPlugin;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 
 import java.io.PrintStream;
@@ -35,14 +36,14 @@ public abstract class BaseAnsiPluginUnitTests
 	public abstract void ansiSqlCreateDatabaseMigrationSucceeds() throws MigrationFailedException;
 
 	protected void ansiSqlCreateDatabaseMigrationSucceeds(
-		PrintStream output,
+		EventSink eventSink,
 		AnsiSqlDatabaseInstance instance,
 		Migration create,
 		MigrationPlugin createRunner,
 		Migration drop,
 		MigrationPlugin dropRunner) throws MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (instance == null) throw new ArgumentNullException("instance");
 		if (create == null) throw new ArgumentNullException("create");
 		if (createRunner == null) throw new ArgumentNullException("createRunner");
@@ -53,7 +54,7 @@ public abstract class BaseAnsiPluginUnitTests
 		{
 			// Execute
 			createRunner.perform(
-				output,
+				eventSink,
 				create,
 				instance);
 
@@ -63,7 +64,7 @@ public abstract class BaseAnsiPluginUnitTests
 		finally
 		{
 			dropRunner.perform(
-				output,
+				eventSink,
 				drop,
 				instance);
 		}
@@ -72,7 +73,7 @@ public abstract class BaseAnsiPluginUnitTests
 	public abstract void tableExistsForExistentTable() throws MigrationFailedException;
 
 	protected void tableExistsForExistentTable(
-		PrintStream output,
+		EventSink eventSink,
 		DatabaseInstance instance,
 		Migration createDatabase,
 		MigrationPlugin createDatabaseRunner,
@@ -82,7 +83,7 @@ public abstract class BaseAnsiPluginUnitTests
 		MigrationPlugin dropDatabaseRunner) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (instance == null) throw new ArgumentNullException("instance");
 		if (createDatabase == null) throw new ArgumentNullException("createDatabase");
 		if (createDatabaseRunner == null) throw new ArgumentNullException("createDatabaseRunner");
@@ -101,12 +102,12 @@ public abstract class BaseAnsiPluginUnitTests
 		try
 		{
 			createDatabaseRunner.perform(
-				output,
+				eventSink,
 				createDatabase,
 				instance);
 
 			createTableRunner.perform(
-				output,
+				eventSink,
 				createTable,
 				instance);
 
@@ -121,7 +122,7 @@ public abstract class BaseAnsiPluginUnitTests
 		finally
 		{
 			dropDatabaseRunner.perform(
-				output,
+				eventSink,
 				dropDatabase,
 				instance);
 		}
@@ -130,7 +131,7 @@ public abstract class BaseAnsiPluginUnitTests
 	public abstract void tableExistsForNonExistentTable() throws MigrationFailedException;
 
 	protected void tableExistsForNonExistentTable(
-		PrintStream output,
+		EventSink eventSink,
 		DatabaseInstance instance,
 		Migration createDatabase,
 		MigrationPlugin createDatabaseRunner,
@@ -138,7 +139,7 @@ public abstract class BaseAnsiPluginUnitTests
 		MigrationPlugin dropDatabaseRunner) throws
 		MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (instance == null) throw new ArgumentNullException("instance");
 		if (createDatabase == null) throw new ArgumentNullException("createDatabase");
 		if (createDatabaseRunner == null) throw new ArgumentNullException("createDatabaseRunner");
@@ -155,7 +156,7 @@ public abstract class BaseAnsiPluginUnitTests
 		try
 		{
 			createDatabaseRunner.perform(
-				output,
+				eventSink,
 				createDatabase,
 				instance);
 
@@ -170,7 +171,7 @@ public abstract class BaseAnsiPluginUnitTests
 		finally
 		{
 			dropDatabaseRunner.perform(
-				output,
+				eventSink,
 				dropDatabase,
 				instance);
 		}

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/generaldatabase/BaseDatabasePluginUnitTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/generaldatabase/BaseDatabasePluginUnitTests.java
@@ -20,6 +20,7 @@ import co.mv.wb.AssertionResponse;
 import co.mv.wb.Migration;
 import co.mv.wb.MigrationFailedException;
 import co.mv.wb.MigrationPlugin;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
 
 import java.io.PrintStream;
@@ -35,14 +36,14 @@ public abstract class BaseDatabasePluginUnitTests
 	public abstract void databaseExistsAssertionForExistentDatabase() throws MigrationFailedException;
 
 	protected void databaseExistsAssertionForExistentDatabase(
-		PrintStream output,
+		EventSink eventSink,
 		DatabaseInstance instance,
 		Migration create,
 		MigrationPlugin createRunner,
 		Migration drop,
 		MigrationPlugin dropRunner) throws MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (instance == null) throw new ArgumentNullException("instance");
 		if (create == null) throw new ArgumentNullException("create");
 		if (createRunner == null) throw new ArgumentNullException("createRunner");
@@ -61,7 +62,7 @@ public abstract class BaseDatabasePluginUnitTests
 		{
 			// Use the migration to create the database
 			createRunner.perform(
-				output,
+				eventSink,
 				create,
 				instance);
 
@@ -86,7 +87,7 @@ public abstract class BaseDatabasePluginUnitTests
 		finally
 		{
 			dropRunner.perform(
-				output,
+				eventSink,
 				drop,
 				instance);
 		}
@@ -119,14 +120,14 @@ public abstract class BaseDatabasePluginUnitTests
 	public abstract void databaseDoesNotExistAssertionForExistentDatabase() throws MigrationFailedException;
 
 	protected void databaseDoesNotExistAssertionForExistentDatabase(
-		PrintStream output,
+		EventSink eventSink,
 		DatabaseInstance instance,
 		Migration create,
 		MigrationPlugin createRunner,
 		Migration drop,
 		MigrationPlugin dropRunner) throws MigrationFailedException
 	{
-		if (output == null) throw new ArgumentNullException("output");
+		if (eventSink == null) throw new ArgumentNullException("eventSink");
 		if (instance == null) throw new ArgumentNullException("instance");
 		if (create == null) throw new ArgumentNullException("create");
 		if (createRunner == null) throw new ArgumentNullException("createRunner");
@@ -141,7 +142,7 @@ public abstract class BaseDatabasePluginUnitTests
 		try
 		{
 			createRunner.perform(
-				output,
+				eventSink,
 				create,
 				instance);
 
@@ -159,7 +160,7 @@ public abstract class BaseDatabasePluginUnitTests
 		finally
 		{
 			dropRunner.perform(
-				output,
+				eventSink,
 				drop,
 				instance);
 		}

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/IntegrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/IntegrationTests.java
@@ -33,6 +33,7 @@ import co.mv.wb.TargetNotSpecifiedException;
 import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.fixture.ProductCatalogueMySqlDatabaseResource;
 import co.mv.wb.fixture.XmlBuilder;
 import co.mv.wb.framework.ArgumentNullException;
@@ -46,6 +47,8 @@ import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigration;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigrationPlugin;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.PrintStream;
@@ -64,6 +67,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class IntegrationTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(IntegrationTests.class);
 	@Test
 	public void createDatabaseAddTableInsertRows() throws
 		AssertionFailedException,
@@ -80,11 +84,10 @@ public class IntegrationTests
 		//
 		// Setup
 		//
-
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -225,11 +228,9 @@ public class IntegrationTests
 		UnknownStateSpecifiedException,
 		InvalidReferenceException
 	{
-
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/MySqlCreateDatabaseMigrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/MySqlCreateDatabaseMigrationTests.java
@@ -17,9 +17,14 @@
 package co.mv.wb.plugin.mysql;
 
 import co.mv.wb.MigrationFailedException;
+import co.mv.wb.event.Event;
+import co.mv.wb.event.EventSink;
+import co.mv.wb.plugin.generaldatabase.AnsiSqlCreateDatabaseMigrationPlugin;
 import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -27,13 +32,12 @@ import java.util.UUID;
 
 public class MySqlCreateDatabaseMigrationTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(AnsiSqlCreateDatabaseMigrationPlugin.class);
 	@Test
 	public void performForNonExistantDatabaseSucceeds() throws
 		MigrationFailedException
 	{
-		// Setup
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		MySqlProperties mySqlProperties = MySqlProperties.get();
 
 		MySqlCreateDatabaseMigration migration = new MySqlCreateDatabaseMigration(
@@ -55,7 +59,7 @@ public class MySqlCreateDatabaseMigrationTests
 
 		// Execute
 		migrationPlugin.perform(
-			output,
+			eventSink,
 			migration,
 			instance);
 
@@ -70,9 +74,7 @@ public class MySqlCreateDatabaseMigrationTests
 	@Test
 	public void performForExistantDatabaseFails()
 	{
-		// Setup
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		MySqlProperties mySqlProperties = MySqlProperties.get();
 
 		String databaseName = MySqlUtil.createDatabase(
@@ -101,7 +103,7 @@ public class MySqlCreateDatabaseMigrationTests
 		try
 		{
 			migrationPlugin.perform(
-				output,
+				eventSink,
 				migration,
 				instance);
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/MySqlPluginUnitTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/MySqlPluginUnitTests.java
@@ -19,9 +19,12 @@ package co.mv.wb.plugin.mysql;
 import co.mv.wb.Migration;
 import co.mv.wb.MigrationFailedException;
 import co.mv.wb.MigrationPlugin;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.generaldatabase.BaseDatabasePluginUnitTests;
 import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -34,12 +37,13 @@ import java.util.UUID;
  */
 public class MySqlPluginUnitTests extends BaseDatabasePluginUnitTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(MySqlPluginUnitTests.class);
+
 	@Override
 	@Test
 	public void databaseExistsAssertionForExistentDatabase() throws MigrationFailedException
 	{
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		String databaseName = DatabaseFixtureHelper.databaseName();
 		MySqlDatabaseInstance instance = MySqlProperties.get().toInstance(databaseName);
 
@@ -58,7 +62,7 @@ public class MySqlPluginUnitTests extends BaseDatabasePluginUnitTests
 		MigrationPlugin dropRunner = new MySqlDropDatabaseMigrationPlugin();
 
 		this.databaseExistsAssertionForExistentDatabase(
-			output,
+			eventSink,
 			instance,
 			create,
 			createRunner,
@@ -80,7 +84,7 @@ public class MySqlPluginUnitTests extends BaseDatabasePluginUnitTests
 	@Test
 	public void databaseDoesNotExistAssertionForExistentDatabase() throws MigrationFailedException
 	{
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		String databaseName = DatabaseFixtureHelper.databaseName();
 		MySqlDatabaseInstance instance = MySqlProperties.get().toInstance(databaseName);
@@ -100,7 +104,7 @@ public class MySqlPluginUnitTests extends BaseDatabasePluginUnitTests
 		MigrationPlugin dropRunner = new MySqlDropDatabaseMigrationPlugin();
 
 		this.databaseDoesNotExistAssertionForExistentDatabase(
-			output,
+			eventSink,
 			instance,
 			create,
 			createRunner,

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/MySqlTableDoesNotExistAssertionTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/MySqlTableDoesNotExistAssertionTests.java
@@ -32,6 +32,7 @@ import co.mv.wb.TargetNotSpecifiedException;
 import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.base.ImmutableState;
 import co.mv.wb.plugin.base.ResourceImpl;
 import co.mv.wb.plugin.fake.FakeInstance;
@@ -39,6 +40,8 @@ import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigration;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigrationPlugin;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.sql.SQLException;
@@ -58,6 +61,7 @@ import static org.junit.Assert.fail;
  */
 public class MySqlTableDoesNotExistAssertionTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(MySqlTableDoesNotExistAssertionTests.class);
 	@Test
 	public void applyForExistingTableFails() throws
 		IndeterminateStateException,
@@ -71,11 +75,9 @@ public class MySqlTableDoesNotExistAssertionTests
 		//
 		// Setup
 		//
-
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -176,11 +178,9 @@ public class MySqlTableDoesNotExistAssertionTests
 		//
 		// Setup
 		//
-
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/MySqlTableExistsAssertionTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/MySqlTableExistsAssertionTests.java
@@ -32,13 +32,18 @@ import co.mv.wb.TargetNotSpecifiedException;
 import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
+import co.mv.wb.event.Event;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.base.ImmutableState;
 import co.mv.wb.plugin.base.ResourceImpl;
+import co.mv.wb.plugin.base.dom.ResourceLoaderIntegrationTests;
 import co.mv.wb.plugin.fake.FakeInstance;
 import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigration;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigrationPlugin;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.sql.SQLException;
@@ -58,6 +63,8 @@ import static org.junit.Assert.fail;
  */
 public class MySqlTableExistsAssertionTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(ResourceLoaderIntegrationTests.class);
+
 	@Test
 	public void applyForExistingTableSucceeds() throws
 		AssertionFailedException,
@@ -75,10 +82,10 @@ public class MySqlTableExistsAssertionTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -173,10 +180,10 @@ public class MySqlTableExistsAssertionTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/SqlScriptMigrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/mysql/SqlScriptMigrationTests.java
@@ -20,16 +20,19 @@ import co.mv.wb.Instance;
 import co.mv.wb.Migration;
 import co.mv.wb.MigrationFailedException;
 import co.mv.wb.MigrationPlugin;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigration;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigrationPlugin;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.PrintStream;
 import java.util.Optional;
 import java.util.UUID;
 
 public class SqlScriptMigrationTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(SqlScriptMigrationTests.class);
 	public SqlScriptMigrationTests()
 	{
 	}
@@ -37,9 +40,7 @@ public class SqlScriptMigrationTests
 	@Test
 	public void performSuccessfully() throws MigrationFailedException
 	{
-		// Setup
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		MySqlProperties mySqlProperties = MySqlProperties.get();
 
 		String databaseName = MySqlUtil.createDatabase(mySqlProperties, "stm_test", "");
@@ -64,7 +65,7 @@ public class SqlScriptMigrationTests
 		try
 		{
 			migrationPlugin.perform(
-				output,
+				eventSink,
 				migration,
 				instance);
 		}

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/postgresql/PostgreSqlAnsiPluginUnitTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/postgresql/PostgreSqlAnsiPluginUnitTests.java
@@ -19,6 +19,7 @@ package co.mv.wb.plugin.postgresql;
 import co.mv.wb.Migration;
 import co.mv.wb.MigrationFailedException;
 import co.mv.wb.MigrationPlugin;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.generaldatabase.AnsiSqlCreateDatabaseMigration;
 import co.mv.wb.plugin.generaldatabase.AnsiSqlCreateDatabaseMigrationPlugin;
 import co.mv.wb.plugin.generaldatabase.AnsiSqlDropDatabaseMigration;
@@ -27,6 +28,8 @@ import co.mv.wb.plugin.generaldatabase.BaseAnsiPluginUnitTests;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigration;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigrationPlugin;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -39,12 +42,12 @@ import java.util.UUID;
  */
 public class PostgreSqlAnsiPluginUnitTests extends BaseAnsiPluginUnitTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(PostgreSqlAnsiPluginUnitTests.class);
 	@Override
 	@Test
 	public void ansiSqlCreateDatabaseMigrationSucceeds() throws MigrationFailedException
 	{
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		PostgreSqlDatabaseInstance instance = new PostgreSqlDatabaseInstance(
 			"127.0.0.1",
 			5432,
@@ -69,7 +72,7 @@ public class PostgreSqlAnsiPluginUnitTests extends BaseAnsiPluginUnitTests
 		MigrationPlugin dropRunner = new AnsiSqlDropDatabaseMigrationPlugin();
 
 		this.ansiSqlCreateDatabaseMigrationSucceeds(
-			output,
+			eventSink,
 			instance,
 			create,
 			createRunner,
@@ -81,7 +84,7 @@ public class PostgreSqlAnsiPluginUnitTests extends BaseAnsiPluginUnitTests
 	@Test
 	public void tableExistsForExistentTable() throws MigrationFailedException
 	{
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		PostgreSqlDatabaseInstance instance = new PostgreSqlDatabaseInstance(
 			"127.0.0.1",
@@ -115,7 +118,7 @@ public class PostgreSqlAnsiPluginUnitTests extends BaseAnsiPluginUnitTests
 		MigrationPlugin dropDatabaseRunner = new AnsiSqlDropDatabaseMigrationPlugin();
 
 		this.tableExistsForExistentTable(
-			output,
+			eventSink,
 			instance,
 			createDatabase,
 			createDatabaseRunner,
@@ -129,7 +132,7 @@ public class PostgreSqlAnsiPluginUnitTests extends BaseAnsiPluginUnitTests
 	@Test
 	public void tableExistsForNonExistentTable() throws MigrationFailedException
 	{
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		PostgreSqlDatabaseInstance instance = new PostgreSqlDatabaseInstance(
 			"127.0.0.1",
@@ -155,7 +158,7 @@ public class PostgreSqlAnsiPluginUnitTests extends BaseAnsiPluginUnitTests
 		MigrationPlugin dropRunner = new AnsiSqlDropDatabaseMigrationPlugin();
 
 		this.tableExistsForNonExistentTable(
-			output,
+			eventSink,
 			instance,
 			create,
 			createRunner,

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/postgresql/PostgreSqlDatabasePluginUnitTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/postgresql/PostgreSqlDatabasePluginUnitTests.java
@@ -19,12 +19,15 @@ package co.mv.wb.plugin.postgresql;
 import co.mv.wb.Migration;
 import co.mv.wb.MigrationFailedException;
 import co.mv.wb.MigrationPlugin;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.generaldatabase.AnsiSqlCreateDatabaseMigration;
 import co.mv.wb.plugin.generaldatabase.AnsiSqlCreateDatabaseMigrationPlugin;
 import co.mv.wb.plugin.generaldatabase.AnsiSqlDropDatabaseMigration;
 import co.mv.wb.plugin.generaldatabase.AnsiSqlDropDatabaseMigrationPlugin;
 import co.mv.wb.plugin.generaldatabase.BaseDatabasePluginUnitTests;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -37,11 +40,12 @@ import java.util.UUID;
  */
 public class PostgreSqlDatabasePluginUnitTests extends BaseDatabasePluginUnitTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(PostgreSqlDatabasePluginUnitTests.class);
 	@Override
 	@Test
 	public void databaseExistsAssertionForExistentDatabase() throws MigrationFailedException
 	{
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		PostgreSqlDatabaseInstance instance = new PostgreSqlDatabaseInstance(
 			"127.0.0.1",
@@ -67,7 +71,7 @@ public class PostgreSqlDatabasePluginUnitTests extends BaseDatabasePluginUnitTes
 		MigrationPlugin dropRunner = new AnsiSqlDropDatabaseMigrationPlugin();
 
 		this.databaseExistsAssertionForExistentDatabase(
-			output,
+			eventSink,
 			instance,
 			create,
 			createRunner,
@@ -95,7 +99,7 @@ public class PostgreSqlDatabasePluginUnitTests extends BaseDatabasePluginUnitTes
 	@Test
 	public void databaseDoesNotExistAssertionForExistentDatabase() throws MigrationFailedException
 	{
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		PostgreSqlDatabaseInstance instance = new PostgreSqlDatabaseInstance(
 			"127.0.0.1",
@@ -121,7 +125,7 @@ public class PostgreSqlDatabasePluginUnitTests extends BaseDatabasePluginUnitTes
 		MigrationPlugin dropRunner = new AnsiSqlDropDatabaseMigrationPlugin();
 
 		this.databaseDoesNotExistAssertionForExistentDatabase(
-			output,
+			eventSink,
 			instance,
 			create,
 			createRunner,

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerCreateDatabaseMigrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerCreateDatabaseMigrationTests.java
@@ -17,8 +17,11 @@
 package co.mv.wb.plugin.sqlserver;
 
 import co.mv.wb.MigrationFailedException;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.sql.SQLException;
@@ -30,13 +33,12 @@ import static org.junit.Assert.fail;
 
 public class SqlServerCreateDatabaseMigrationTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(SqlServerCreateDatabaseMigrationTests.class);
+
 	@Test
 	public void performForNonExistantDatabaseSucceeds() throws
 		MigrationFailedException
 	{
-		// Setup
-		PrintStream output = System.out;
-
 		SqlServerProperties p = SqlServerProperties.get();
 
 		SqlServerCreateDatabaseMigration migration = new SqlServerCreateDatabaseMigration(
@@ -58,10 +60,12 @@ public class SqlServerCreateDatabaseMigrationTests
 			null);
 
 		// Execute
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+
 		try
 		{
 			migrationPlugin.perform(
-				output,
+				eventSink,
 				migration,
 				instance);
 		}
@@ -75,9 +79,7 @@ public class SqlServerCreateDatabaseMigrationTests
 	@Test
 	public void performForExistantDatabaseFails() throws SQLException
 	{
-		// Setup
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		SqlServerProperties properties = SqlServerProperties.get();
 
 		SqlServerDatabaseInstance instance = new SqlServerDatabaseInstance(
@@ -102,7 +104,7 @@ public class SqlServerCreateDatabaseMigrationTests
 		try
 		{
 			migrationPlugin.perform(
-				output,
+				eventSink,
 				migration,
 				instance);
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerCreateSchemaMigrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerCreateSchemaMigrationTests.java
@@ -17,8 +17,11 @@
 package co.mv.wb.plugin.sqlserver;
 
 import co.mv.wb.MigrationFailedException;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.sql.SQLException;
@@ -30,12 +33,13 @@ import static org.junit.Assert.fail;
 
 public class SqlServerCreateSchemaMigrationTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(SqlServerCreateSchemaMigrationTests.class);
 	@Test
 	public void performForNonExistantSchemaSucceeds() throws
 		MigrationFailedException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		String databaseName = DatabaseFixtureHelper.databaseName();
 		SqlServerDatabaseInstance instance = SqlServerProperties.get().toInstance(databaseName);
@@ -49,7 +53,7 @@ public class SqlServerCreateSchemaMigrationTests
 		SqlServerCreateDatabaseMigrationPlugin createDatabaseRunner = new SqlServerCreateDatabaseMigrationPlugin();
 
 		createDatabaseRunner.perform(
-			output,
+			eventSink,
 			createDatabase,
 			instance);
 
@@ -66,7 +70,7 @@ public class SqlServerCreateSchemaMigrationTests
 		{
 			// Execute
 			createSchemaRunner.perform(
-				output,
+				eventSink,
 				createSchema,
 				instance);
 		}
@@ -81,7 +85,7 @@ public class SqlServerCreateSchemaMigrationTests
 	public void performForExistantSchemaFails() throws SQLException, MigrationFailedException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		String databaseName = DatabaseFixtureHelper.databaseName();
 		SqlServerDatabaseInstance instance = SqlServerProperties.get().toInstance(databaseName);
@@ -95,7 +99,7 @@ public class SqlServerCreateSchemaMigrationTests
 		SqlServerCreateDatabaseMigrationPlugin createDatabaseRunner = new SqlServerCreateDatabaseMigrationPlugin();
 
 		createDatabaseRunner.perform(
-			output,
+			eventSink,
 			createDatabase,
 			instance);
 
@@ -109,7 +113,7 @@ public class SqlServerCreateSchemaMigrationTests
 		SqlServerCreateSchemaMigrationPlugin createSchemaRunner = new SqlServerCreateSchemaMigrationPlugin();
 
 		createSchemaRunner.perform(
-			output,
+			eventSink,
 			createSchema,
 			instance);
 
@@ -119,7 +123,7 @@ public class SqlServerCreateSchemaMigrationTests
 		try
 		{
 			createSchemaRunner.perform(
-				output,
+				eventSink,
 				createSchema,
 				instance);
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerDropSchemaMigrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerDropSchemaMigrationTests.java
@@ -17,8 +17,11 @@
 package co.mv.wb.plugin.sqlserver;
 
 import co.mv.wb.MigrationFailedException;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.sql.SQLException;
@@ -30,12 +33,14 @@ import static org.junit.Assert.fail;
 
 public class SqlServerDropSchemaMigrationTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(SqlServerDropSchemaMigrationTests.class);
 	@Test
 	public void performForExistantSchemaSucceeds() throws
 		MigrationFailedException
 	{
 		// Setup
-		PrintStream output = System.out;
+
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		SqlServerProperties p = SqlServerProperties.get();
 
@@ -58,7 +63,7 @@ public class SqlServerDropSchemaMigrationTests
 			null);
 
 		createDatabaseRunner.perform(
-			output,
+			eventSink,
 			createDatabase,
 			instance);
 
@@ -71,7 +76,7 @@ public class SqlServerDropSchemaMigrationTests
 		SqlServerCreateSchemaMigrationPlugin createSchemaRunner = new SqlServerCreateSchemaMigrationPlugin();
 
 		createSchemaRunner.perform(
-			output,
+			eventSink,
 			createSchema,
 			instance);
 
@@ -87,7 +92,7 @@ public class SqlServerDropSchemaMigrationTests
 		{
 			// Execute
 			dropSchemaRunner.perform(
-				output,
+				eventSink,
 				dropSchema,
 				instance);
 		}
@@ -102,7 +107,8 @@ public class SqlServerDropSchemaMigrationTests
 	public void performForNonExistantSchemaFails() throws SQLException, MigrationFailedException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+
 
 		SqlServerProperties p = SqlServerProperties.get();
 
@@ -125,7 +131,7 @@ public class SqlServerDropSchemaMigrationTests
 			null);
 
 		createDatabaseRunner.perform(
-			output,
+			eventSink,
 			createDatabase,
 			instance);
 
@@ -141,7 +147,7 @@ public class SqlServerDropSchemaMigrationTests
 		{
 			// Execute
 			dropSchemaRunner.perform(
-				output,
+				eventSink,
 				dropSchema,
 				instance);
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerPluginUnitTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerPluginUnitTests.java
@@ -19,9 +19,14 @@ package co.mv.wb.plugin.sqlserver;
 import co.mv.wb.Migration;
 import co.mv.wb.MigrationFailedException;
 import co.mv.wb.MigrationPlugin;
+import co.mv.wb.event.Event;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.generaldatabase.BaseDatabasePluginUnitTests;
 import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
+import co.mv.wb.plugin.postgresql.PostgreSqlAnsiPluginUnitTests;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -34,11 +39,12 @@ import java.util.UUID;
  */
 public class SqlServerPluginUnitTests extends BaseDatabasePluginUnitTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(SqlServerPluginUnitTests.class);
 	@Override
 	@Test
 	public void databaseExistsAssertionForExistentDatabase() throws MigrationFailedException
 	{
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		String databaseName = DatabaseFixtureHelper.databaseName();
 		SqlServerDatabaseInstance instance = SqlServerProperties.get().toInstance(databaseName);
@@ -58,7 +64,7 @@ public class SqlServerPluginUnitTests extends BaseDatabasePluginUnitTests
 		MigrationPlugin dropRunner = new SqlServerDropDatabaseMigrationPlugin();
 
 		this.databaseExistsAssertionForExistentDatabase(
-			output,
+			eventSink,
 			instance,
 			create,
 			createRunner,
@@ -80,7 +86,7 @@ public class SqlServerPluginUnitTests extends BaseDatabasePluginUnitTests
 	@Test
 	public void databaseDoesNotExistAssertionForExistentDatabase() throws MigrationFailedException
 	{
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		String databaseName = DatabaseFixtureHelper.databaseName();
 		SqlServerDatabaseInstance instance = SqlServerProperties.get().toInstance(databaseName);
@@ -100,7 +106,7 @@ public class SqlServerPluginUnitTests extends BaseDatabasePluginUnitTests
 		MigrationPlugin dropRunner = new SqlServerDropDatabaseMigrationPlugin();
 
 		this.databaseDoesNotExistAssertionForExistentDatabase(
-			output,
+			eventSink,
 			instance,
 			create,
 			createRunner,

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerSchemaDoesNotExistAssertionTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerSchemaDoesNotExistAssertionTests.java
@@ -21,9 +21,13 @@ import co.mv.wb.Asserts;
 import co.mv.wb.Migration;
 import co.mv.wb.MigrationFailedException;
 import co.mv.wb.MigrationPlugin;
+import co.mv.wb.event.EventSink;
+import co.mv.wb.impl.WildebeestApiImplJumpStateIntegrationTests;
 import co.mv.wb.plugin.fake.FakeInstance;
 import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -40,13 +44,13 @@ import static org.junit.Assert.fail;
  */
 public class SqlServerSchemaDoesNotExistAssertionTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(WildebeestApiImplJumpStateIntegrationTests.class);
+
 	@Test
 	public void applyForExistingSchemaFails() throws
 		MigrationFailedException
 	{
 		// Setup
-		PrintStream output = System.out;
-
 		SqlServerProperties properties = SqlServerProperties.get();
 
 		String databaseName = DatabaseFixtureHelper.databaseName();
@@ -65,9 +69,9 @@ public class SqlServerSchemaDoesNotExistAssertionTests
 			Optional.of(UUID.randomUUID().toString()));
 
 		MigrationPlugin createDatabaseRunner = new SqlServerCreateDatabaseMigrationPlugin();
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		createDatabaseRunner.perform(
-			output,
+			eventSink,
 			createDatabase,
 			instance);
 
@@ -80,7 +84,7 @@ public class SqlServerSchemaDoesNotExistAssertionTests
 		MigrationPlugin createSchemaRunner = new SqlServerCreateSchemaMigrationPlugin();
 
 		createSchemaRunner.perform(
-			output,
+			eventSink,
 			createSchema,
 			instance);
 
@@ -111,9 +115,7 @@ public class SqlServerSchemaDoesNotExistAssertionTests
 	public void applyForNonExistentSchemaSucceeds() throws
 		MigrationFailedException
 	{
-		// Setup
-		PrintStream output = System.out;
-
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 		SqlServerProperties properties = SqlServerProperties.get();
 
 		String databaseName = DatabaseFixtureHelper.databaseName();
@@ -135,7 +137,7 @@ public class SqlServerSchemaDoesNotExistAssertionTests
 		MigrationPlugin createDatabaseRunner = new SqlServerCreateDatabaseMigrationPlugin();
 
 		createDatabaseRunner.perform(
-			output,
+			eventSink,
 			createDatabase,
 			instance);
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerSchemaExistsAssertionTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerSchemaExistsAssertionTests.java
@@ -21,9 +21,12 @@ import co.mv.wb.Asserts;
 import co.mv.wb.Migration;
 import co.mv.wb.MigrationFailedException;
 import co.mv.wb.MigrationPlugin;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.fake.FakeInstance;
 import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -40,12 +43,14 @@ import static org.junit.Assert.fail;
  */
 public class SqlServerSchemaExistsAssertionTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(SqlServerSchemaExistsAssertionTests.class);
 	@Test
 	public void applyForExistingSchemaSucceeds() throws
 		MigrationFailedException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+
 
 		SqlServerProperties properties = SqlServerProperties.get();
 
@@ -67,7 +72,7 @@ public class SqlServerSchemaExistsAssertionTests
 		MigrationPlugin createDatabaseRunner = new SqlServerCreateDatabaseMigrationPlugin();
 
 		createDatabaseRunner.perform(
-			output,
+			eventSink,
 			createDatabase,
 			instance);
 
@@ -80,7 +85,7 @@ public class SqlServerSchemaExistsAssertionTests
 		MigrationPlugin createSchemaRunner = new SqlServerCreateSchemaMigrationPlugin();
 
 		createSchemaRunner.perform(
-			output,
+			eventSink,
 			createSchema,
 			instance);
 
@@ -116,7 +121,8 @@ public class SqlServerSchemaExistsAssertionTests
 		MigrationFailedException
 	{
 		// Setup
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
+
 
 		SqlServerProperties properties = SqlServerProperties.get();
 
@@ -139,7 +145,7 @@ public class SqlServerSchemaExistsAssertionTests
 		MigrationPlugin createDatabaseRunner = new SqlServerCreateDatabaseMigrationPlugin();
 
 		createDatabaseRunner.perform(
-			output,
+			eventSink,
 			createDatabase,
 			instance);
 

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerTableDoesNotExistAssertionTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerTableDoesNotExistAssertionTests.java
@@ -32,6 +32,7 @@ import co.mv.wb.TargetNotSpecifiedException;
 import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.base.ImmutableState;
 import co.mv.wb.plugin.base.ResourceImpl;
 import co.mv.wb.plugin.fake.FakeInstance;
@@ -39,6 +40,8 @@ import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigration;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigrationPlugin;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.sql.SQLException;
@@ -58,6 +61,7 @@ import static org.junit.Assert.fail;
  */
 public class SqlServerTableDoesNotExistAssertionTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(SqlServerPluginUnitTests.class);
 	@Test
 	public void applyForExistingTableFails() throws
 		AssertionFailedException,
@@ -73,11 +77,10 @@ public class SqlServerTableDoesNotExistAssertionTests
 		//
 		// Setup
 		//
-
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -178,10 +181,10 @@ public class SqlServerTableDoesNotExistAssertionTests
 		// Setup
 		//
 
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.withFactoryMigrationPlugins()
 			.get();

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerTableExistsAssertionTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/sqlserver/SqlServerTableExistsAssertionTests.java
@@ -32,6 +32,9 @@ import co.mv.wb.TargetNotSpecifiedException;
 import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
+import co.mv.wb.cli.WildebeestCommand;
+import co.mv.wb.event.Event;
+import co.mv.wb.event.EventSink;
 import co.mv.wb.plugin.base.ImmutableState;
 import co.mv.wb.plugin.base.ResourceImpl;
 import co.mv.wb.plugin.fake.FakeInstance;
@@ -39,6 +42,8 @@ import co.mv.wb.plugin.generaldatabase.DatabaseFixtureHelper;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigration;
 import co.mv.wb.plugin.generaldatabase.SqlScriptMigrationPlugin;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.util.HashMap;
@@ -57,6 +62,8 @@ import static org.junit.Assert.fail;
  */
 public class SqlServerTableExistsAssertionTests
 {
+	private static final Logger LOG = LoggerFactory.getLogger(SqlServerTableExistsAssertionTests.class);
+
 	@Test
 	public void applyForExistingTableSucceeds() throws
 		AssertionFailedException,
@@ -72,11 +79,10 @@ public class SqlServerTableExistsAssertionTests
 		//
 		// Setup
 		//
-
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.get();
 
@@ -175,11 +181,10 @@ public class SqlServerTableExistsAssertionTests
 		//
 		// Setup
 		//
-
-		PrintStream output = System.out;
+		EventSink eventSink = (event) -> {if(event.getMessage().isPresent()) LOG.info(event.getMessage().get());};
 
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(output)
+			.wildebeestApi(eventSink)
 			.withFactoryResourcePlugins()
 			.withFactoryMigrationPlugins()
 			.get();


### PR DESCRIPTION
a.  Change all PrintStream out to EventSink
b.  Added a command logger to show only message with no extra information.
c.  Fix jump state bug where assertion to state is done before jumping to that state instead of after jumping to that state
d.  Added different type of events that can be used for printing out messages
to log file:  CommandLineEvent, MigrationEvent, JumpStateEvent, StateEvent,
AssertionEvent
e.  Added a seperate console logger for WildebeestCommand for displaying
command outputs without extra log formatting.