### PR TITLE
MVWB-101:  Finished implementation of migration log

### DIFF
--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/AssertionEvent.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/AssertionEvent.java
@@ -16,12 +16,14 @@
 
 package co.mv.wb.event;
 
+import co.mv.wb.Assertion;
+
 /**
  * Defines an event for Assertion
  *
  * @since 4.0
  */
-public class AssertionEvent extends Event
+public class AssertionEvent extends ResourceEvent<Assertion>
 {
 	/**
 	 * Provides all events associated with Assertion.
@@ -32,56 +34,67 @@ public class AssertionEvent extends Event
 	{
 		START,
 		COMPLETE,
-		FAILED;
+		FAILED
 	}
 
 	/**
 	 * Constructs a new AssertionEvent with the supplied details.
 	 *
-	 * @param name    the name of the event
-	 * @param message the message of the event
+	 * @param name      the name of the event
+	 * @param message   the message of the event
+	 * @param assertion the source {@link Assertion} of the event
 	 * @since 4.0
 	 */
 	public AssertionEvent(
 		String name,
-		String message)
+		String message,
+		Assertion assertion)
 	{
-		super(name, message);
+		super(name, message, assertion);
 	}
 
 	/**
 	 * Creates an AssertionEvent for Start Event.
 	 *
-	 * @param message the message of the event
+	 * @param message   the message of the event
+	 * @param assertion the source {@link Assertion} of the event
 	 * @return the AssertionEvent created for Start Event
 	 * @since 4.0
 	 */
-	public static AssertionEvent start(String message)
+	public static AssertionEvent start(
+		String message,
+		Assertion assertion)
 	{
-		return new AssertionEvent(Name.START.name(), message);
+		return new AssertionEvent(Name.START.name(), message, assertion);
 	}
 
 	/**
 	 * Creates an AssertionEvent for Complete Event.
 	 *
-	 * @param message the message of the event
+	 * @param message   the message of the event
+	 * @param assertion the source {@link Assertion} of the event
 	 * @return the AssertionEvent created for Complete Event
 	 * @since 4.0
 	 */
-	public static AssertionEvent complete(String message)
+	public static AssertionEvent complete(
+		String message,
+		Assertion assertion)
 	{
-		return new AssertionEvent(Name.COMPLETE.name(), message);
+		return new AssertionEvent(Name.COMPLETE.name(), message, assertion);
 	}
 
 	/**
 	 * Creates an AssertionEvent for Failed Event.
 	 *
-	 * @param message the message of the event
+	 * @param message   the message of the event
+	 * @param assertion the source {@link Assertion} of the event
 	 * @return the AssertionEvent created for Failed Event
 	 * @since 4.0
 	 */
-	public static AssertionEvent failed(String message)
+	public static AssertionEvent failed(
+		String message,
+		Assertion assertion)
 	{
-		return new AssertionEvent(Name.FAILED.name(), message);
+		return new AssertionEvent(Name.FAILED.name(), message, assertion);
 	}
 }

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/JumpStateEvent.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/JumpStateEvent.java
@@ -16,10 +16,12 @@
 
 package co.mv.wb.event;
 
-public class JumpStateEvent extends Event
+import co.mv.wb.State;
+
+public class JumpStateEvent extends ResourceEvent<State>
 {
 	/**
-	 * Provides all events associated with JumpState Event.
+	 * Provides all events associated with JumpState ResourceEvent.
 	 *
 	 * @since 4.0
 	 */
@@ -27,54 +29,67 @@ public class JumpStateEvent extends Event
 	{
 		START,
 		COMPLETE,
-		FAILED;
+		FAILED
 	}
 
 	/**
-	 * Constructs a new Event with the supplied details.
+	 * Constructs a new ResourceEvent with the supplied details.
 	 *
-	 * @param name    the name of the event, this should be supplied from Event
+	 * @param name    the name of the event, this should be supplied from ResourceEvent
 	 * @param message a message of the event
+	 * @param state   the source {@link State} of the event
 	 * @since 4.0
 	 */
 	public JumpStateEvent(
 		String name,
-		String message)
+		String message,
+		State state)
 	{
-		super(name, message);
+		super(name, message, state);
 	}
 
 	/**
-	 * Creates an JumpStateEvent for Start Event.
-	 *
-	 * @return the JumpStateEvent created for Start Event
-	 * @since 4.0
-	 */
-	public static JumpStateEvent start(String message)
-	{
-		return new JumpStateEvent(Name.START.name(), message);
-	}
-
-	/**
-	 * Creates an JumpStateEvent for Complete Event.
-	 *
-	 * @return the JumpStateEvent created for Complete Event
-	 * @since 4.0
-	 */
-	public static JumpStateEvent complete(String message)
-	{
-		return new JumpStateEvent(Name.COMPLETE.name(), message);
-	}
-
-	/**
-	 * Creates an JumpStateEvent for Failed Event.
+	 * Creates an JumpStateEvent for Start ResourceEvent.
 	 *
 	 * @param message the message of the event
-	 * @return the JumpStateEvent created for Failed Event
+	 * @param state   the source {@link State} of the event
+	 * @return the JumpStateEvent created for Start ResourceEvent
 	 * @since 4.0
 	 */
-	public static JumpStateEvent failed(String message)
+	public static JumpStateEvent start(
+		String message,
+		State state)
 	{
-		return new JumpStateEvent(Name.FAILED.name(), message);
+		return new JumpStateEvent(Name.START.name(), message, state);
+	}
+
+	/**
+	 * Creates an JumpStateEvent for Complete ResourceEvent.
+	 *
+	 * @param message the message of the event
+	 * @param state   the source {@link State} of the event
+	 * @return the JumpStateEvent created for Complete ResourceEvent
+	 * @since 4.0
+	 */
+	public static JumpStateEvent complete(
+		String message,
+		State state)
+	{
+		return new JumpStateEvent(Name.COMPLETE.name(), message, state);
+	}
+
+	/**
+	 * Creates an JumpStateEvent for Failed ResourceEvent.
+	 *
+	 * @param message the message of the event
+	 * @param state   the source {@link State} of the event
+	 * @return the JumpStateEvent created for Failed ResourceEvent
+	 * @since 4.0
+	 */
+	public static JumpStateEvent failed(
+		String message,
+		State state)
+	{
+		return new JumpStateEvent(Name.FAILED.name(), message, state);
 	}
 }

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/MigrationEvent.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/MigrationEvent.java
@@ -16,12 +16,14 @@
 
 package co.mv.wb.event;
 
+import co.mv.wb.Migration;
+
 /**
  * Defines an event for Migration
  *
  * @since 4.0
  */
-public class MigrationEvent extends Event
+public class MigrationEvent extends ResourceEvent<Migration>
 {
 	/**
 	 * Provides all events associated with Migration.
@@ -32,56 +34,67 @@ public class MigrationEvent extends Event
 	{
 		START,
 		COMPLETE,
-		FAILED;
+		FAILED
 	}
 
 	/**
 	 * Constructs a new MigrationEvent with the supplied details.
 	 *
-	 * @param name    the name of the event
-	 * @param message the message of the event
+	 * @param name      the name of the event
+	 * @param message   the message of the event
+	 * @param migration the source {@link Migration} of the event
 	 * @since 4.0
 	 */
 	public MigrationEvent(
 		String name,
-		String message)
+		String message,
+		Migration migration)
 	{
-		super(name, message);
+		super(name, message, migration);
 	}
 
 	/**
-	 * Creates an MigrationEvent for Start Event.
+	 * Creates an MigrationEvent for Start ResourceEvent.
 	 *
-	 * @param message the message of the event
-	 * @return the MigrationEvent created for Start Event
+	 * @param message   the message of the event
+	 * @param migration the source {@link Migration} of the event
+	 * @return the MigrationEvent created for Start ResourceEvent
 	 * @since 4.0
 	 */
-	public static MigrationEvent start(String message)
+	public static MigrationEvent start(
+		String message,
+		Migration migration)
 	{
-		return new MigrationEvent(MigrationEvent.Name.START.name(), message);
+		return new MigrationEvent(Name.START.name(), message, migration);
 	}
 
 	/**
-	 * Creates an MigrationEvent for Complete Event.
+	 * Creates an MigrationEvent for Complete ResourceEvent.
 	 *
-	 * @param message the message of the event
-	 * @return the MigrationEvent created for Complete Event
+	 * @param message   the message of the event
+	 * @param migration the source {@link Migration} of the event
+	 * @return the MigrationEvent created for Complete ResourceEvent
 	 * @since 4.0
 	 */
-	public static MigrationEvent complete(String message)
+	public static MigrationEvent complete(
+		String message,
+		Migration migration)
 	{
-		return new MigrationEvent(MigrationEvent.Name.COMPLETE.name(), message);
+		return new MigrationEvent(Name.COMPLETE.name(), message, migration);
 	}
 
 	/**
-	 * Creates an MigrationEvent for Failed Event.
+	 * Creates an MigrationEvent for Failed ResourceEvent.
 	 *
-	 * @param message the message of the event
-	 * @return the MigrationEvent created for Failed Event
+	 * @param message   the message of the event
+	 * @param migration the source {@link Migration} of the event
+	 * @return the MigrationEvent created for Failed ResourceEvent
 	 * @since 4.0
 	 */
-	public static MigrationEvent failed(String message)
+	public static MigrationEvent failed(
+		String message,
+		Migration migration)
 	{
-		return new MigrationEvent(MigrationEvent.Name.FAILED.name(), message);
+		return new MigrationEvent(Name.FAILED.name(), message, migration);
 	}
 }

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/ResourceEvent.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/ResourceEvent.java
@@ -16,28 +16,36 @@
 
 package co.mv.wb.event;
 
-import co.mv.wb.framework.ArgumentNullException;
-import org.slf4j.Logger;
 
 /**
- * An {@link EventSink} that sends the output to the logger at INFO level.
+ * Defines an ResourceEvent
  *
  * @since 4.0
  */
-public class LoggingEventSink implements EventSink
+public class ResourceEvent<T> extends Event
 {
-	private final Logger logger;
+	private final T elementResource;
 
-	public LoggingEventSink(Logger logger)
+	/**
+	 * Constructs a new ResourceEvent with the supplied details.
+	 *
+	 * @param name            the name of the event, this should be supplied from ResourceEvent
+	 * @param message         a message of the event
+	 * @param elementResource the element resource considered during the event
+	 * @since 4.0
+	 */
+	public ResourceEvent(
+		String name,
+		String message,
+		T elementResource)
 	{
-		if (logger == null) throw new ArgumentNullException("logger");
+		super(name, message);
 
-		this.logger = logger;
+		this.elementResource = elementResource;
 	}
 
-	@Override
-	public void onEvent(Event event)
+	public T getElementResource()
 	{
-		this.logger.info(event.getMessage().orElse(event.getName()));
+		return elementResource;
 	}
 }

--- a/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/StateEvent.java
+++ b/MV.Wildebeest.Api/source/core/java/co/mv/wb/event/StateEvent.java
@@ -16,12 +16,14 @@
 
 package co.mv.wb.event;
 
+import co.mv.wb.State;
+
 /**
  * Defines an event for State
  *
  * @since 4.0
  */
-public class StateEvent extends Event
+public class StateEvent extends ResourceEvent<State>
 {
 	/**
 	 * Provides all events associated with State.
@@ -35,7 +37,7 @@ public class StateEvent extends Event
 		ASSERTION_START,
 		ASSERTION_COMPLETE,
 		CHANGE_SUCCESS,
-		CHANGE_FAILED;
+		CHANGE_FAILED
 	}
 
 	/**
@@ -43,80 +45,101 @@ public class StateEvent extends Event
 	 *
 	 * @param name    the name of the event
 	 * @param message the message of the event
+	 * @param state   the source {@link State} of the event
 	 * @since 4.0
 	 */
 	public StateEvent(
 		String name,
-		String message)
+		String message,
+		State state)
 	{
-		super(name, message);
+		super(name, message, state);
 	}
 
 	/**
-	 * Creates an StateEvent for PreAssert Event.
+	 * Creates an StateEvent for PreAssert ResourceEvent.
 	 *
 	 * @param message the message of the event
-	 * @return the StateEvent created for PreAssert Event
+	 * @param state   the source {@link State} of the event
+	 * @return the StateEvent created for PreAssert ResourceEvent
 	 * @since 4.0
 	 */
-	public static StateEvent preAssert(String message)
+	public static StateEvent preAssert(
+		String message,
+		State state)
 	{
-		return new StateEvent(Name.PRE_ASSERT.name(), message);
+		return new StateEvent(Name.PRE_ASSERT.name(), message, state);
 	}
 
 	/**
-	 * Creates an StateEvent for PostAssert Event.
+	 * Creates an StateEvent for PostAssert ResourceEvent.
 	 *
 	 * @param message the message of the event
-	 * @return the StateEvent created for PreAssert Event
+	 * @param state   the source {@link State} of the event
+	 * @return the StateEvent created for PreAssert ResourceEvent
 	 * @since 4.0
 	 */
-	public static StateEvent postAssert(String message)
+	public static StateEvent postAssert(
+		String message,
+		State state)
 	{
-		return new StateEvent(Name.POST_ASSERT.name(), message);
+		return new StateEvent(Name.POST_ASSERT.name(), message, state);
 	}
 
 	/**
-	 * Creates an StateEvent for AssertionStart Event.
+	 * Creates an StateEvent for AssertionStart ResourceEvent.
 	 *
-	 * @return the StateEvent created for AssertionStart Event
+	 * @param message the message of the event
+	 * @return the StateEvent created for AssertionStart ResourceEvent
 	 * @since 4.0
 	 */
-	public static Event assertionStart(String message)
+	public static StateEvent assertionStart(String message)
 	{
-		return new StateEvent(Name.ASSERTION_START.name(), message);
+		return new StateEvent(Name.ASSERTION_START.name(), message, null);
 	}
 
 	/**
-	 * Creates an StateEvent for AssertionComplete Event.
+	 * Creates an StateEvent for AssertionComplete ResourceEvent.
 	 *
-	 * @return the StateEvent created for AssertionComplete Event
+	 * @param message the message of the event
+	 * @param state   the source {@link State} of the event
+	 * @return the StateEvent created for AssertionComplete ResourceEvent
 	 * @since 4.0
 	 */
-	public static Event assertionComplete(String message)
+	public static StateEvent assertionComplete(
+		String message,
+		State state)
 	{
-		return new StateEvent(Name.ASSERTION_COMPLETE.name(), message);
+		return new StateEvent(Name.ASSERTION_COMPLETE.name(), message, state);
 	}
 
 	/**
-	 * Creates an StateEvent for ChangeSuccess Event.
+	 * Creates an StateEvent for ChangeSuccess ResourceEvent.
 	 *
-	 * @return the StateEvent created for ChangeSuccess Event
+	 * @param message the message of the event
+	 * @param state   the source {@link State} of the event
+	 * @return the StateEvent created for ChangeSuccess ResourceEvent
 	 * @since 4.0
 	 */
-	public static Event changeSuccess(String message)
+	public static StateEvent changeSuccess(
+		String message,
+		State state)
 	{
-		return new StateEvent(Name.CHANGE_SUCCESS.name(), message);
+		return new StateEvent(Name.CHANGE_SUCCESS.name(), message, state);
 	}
 
 	/**
-	 * Creates an StateEvent for ChangeFailed Event.
+	 * Creates an StateEvent for ChangeFailed ResourceEvent.
 	 *
-	 * @return the StateEvent created for ChangeFailed Event
+	 * @param message the message of the event
+	 * @param state   the source {@link State} of the event
+	 * @return the StateEvent created for ChangeFailed ResourceEvent
 	 * @since 4.0
 	 */
-	public static Event changeFailed(String message)
+	public static StateEvent changeFailed(
+		String message,
+		State state)
 	{
-		return new StateEvent(Name.CHANGE_FAILED.name(), message);
+		return new StateEvent(Name.CHANGE_FAILED.name(), message, state);
 	}
 }

--- a/MV.Wildebeest.Core/MV.Wildebeest.Core.iml
+++ b/MV.Wildebeest.Core/MV.Wildebeest.Core.iml
@@ -188,5 +188,23 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/target/core/libcompile/jackson-mapper-asl-1.9.13.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/target/core/libcompile/jackson-core-asl-1.9.13.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/MV.Wildebeest.Core/ivy.xml
+++ b/MV.Wildebeest.Core/ivy.xml
@@ -58,6 +58,8 @@
 		<dependency org="org.opengis.cite.eclipse.webtools.sse" name="org.eclipse.wst.xml.xpath2.processor" rev="1.1.5-738bb7b85d" conf="clr,tlr->default" />
 		<dependency org="xml-apis" name="xml-apis" rev="1.4.01" conf="tlc,tlr->default" />
 		<dependency org="joda-time" name="joda-time" rev="2.10" conf="clc,clr,tlr->default"/>
+		<dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.13" conf="clc,clr,tlc,tlr->default" />
+
 	</dependencies>
 
 </ivy-module>

--- a/MV.Wildebeest.Core/source/core/classtree/log4j.xml
+++ b/MV.Wildebeest.Core/source/core/classtree/log4j.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="true">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
 	<!-- Console Appender -->
 	<appender name="console" class="org.apache.log4j.ConsoleAppender">
 		<param name="Target" value="System.out"/>
@@ -26,6 +26,17 @@
 			<param name="AcceptOnMatch" value="true"/>
 		</filter>
 	</appender>
+	<!-- Migration Log File Appender -->
+	<appender name="migration-log" class="org.apache.log4j.FileAppender">
+		<param name="Append" value="true"/>
+		<param name="File" value="migration.log"/>
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%m%n"/>
+		</layout>
+	</appender>
+	<logger name="migration-logger">
+		<appender-ref ref="migration-log"/>
+	</logger>
 	<root>
 		<appender-ref ref="console"/>
 		<appender-ref ref="wildebeest-log"/>

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/Wildebeest.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/Wildebeest.java
@@ -18,7 +18,6 @@ package co.mv.wb;
 
 import co.mv.wb.event.EventSink;
 import co.mv.wb.framework.ArgumentNullException;
-import co.mv.wb.framework.Util;
 import co.mv.wb.impl.WildebeestApiBuilder;
 import co.mv.wb.plugin.composite.ExternalResourceMigrationPlugin;
 import co.mv.wb.plugin.generaldatabase.AnsiSqlCreateDatabaseMigrationPlugin;
@@ -41,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/cli/WildebeestCommand.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/cli/WildebeestCommand.java
@@ -37,6 +37,8 @@ import co.mv.wb.WildebeestApi;
 import co.mv.wb.XmlValidationException;
 import co.mv.wb.event.EventSink;
 import co.mv.wb.event.LoggingEventSink;
+import co.mv.wb.event.MigrationEventSink;
+import co.mv.wb.event.TeeEventSink;
 import co.mv.wb.framework.ArgumentNullException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,10 +68,12 @@ public class WildebeestCommand
 	public static void main(String[] args)
 	{
 		PrintStream output = System.out;
-		EventSink eventSink = new LoggingEventSink(LOG);
-
+		TeeEventSink teeEventSink = new TeeEventSink(
+				new LoggingEventSink(LOG),
+				new MigrationEventSink(LOG)
+		);
 		WildebeestApi wildebeestApi = Wildebeest
-			.wildebeestApi(eventSink)
+			.wildebeestApi(teeEventSink)
 			.withFactoryPluginGroups()
 			.withFactoryResourcePlugins()
 			.withFactoryMigrationPlugins()

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/event/MigrationEventSink.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/event/MigrationEventSink.java
@@ -1,0 +1,133 @@
+// Wildebeest Migration Framework
+// Copyright © 2013 - 2018, Matheson Ventures Pte Ltd
+//
+// This file is part of Wildebeest
+//
+// Wildebeest is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License v2 as published by the Free
+// Software Foundation.
+//
+// Wildebeest is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Wildebeest.  If not, see http://www.gnu.org/licenses/gpl-2.0.html
+
+package co.mv.wb.event;
+
+import co.mv.wb.Migration;
+import co.mv.wb.framework.ArgumentNullException;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.UUID;
+
+/**
+ * An {@link EventSink} that sends the output to the migration-logger (migration.log).
+ *
+ * @since 4.0
+ */
+public class MigrationEventSink implements EventSink
+{
+	private final Logger migrationLogger = LoggerFactory.getLogger("migration-logger");
+	private final Logger logger;
+	private final ObjectMapper mapper;
+
+	public MigrationEventSink(Logger logger)
+	{
+		if (logger == null) throw new ArgumentNullException("logger");
+
+		this.logger = logger;
+		mapper = new ObjectMapper();
+		TimeZone tz = TimeZone.getTimeZone("UTC");
+		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+		df.setTimeZone(tz);
+		mapper.setDateFormat(df);
+	}
+
+	@Override public void onEvent(Event event)
+	{
+		if (!(event instanceof MigrationEvent)){
+			return;
+		}
+
+		MigrationEvent migrationEvent = (MigrationEvent)event;
+		if (migrationEvent.getName().equals(MigrationEvent.Name.START.name())){
+			return;
+		}
+
+		try
+		{
+			MigrationLog migrationLog = new MigrationLog(migrationEvent);
+			String json = mapper.writeValueAsString(migrationLog);
+			migrationLogger.info(json);
+		}
+		catch (IOException e)
+		{
+			this.logger.error("Exception encountered while writing to migration log", e);
+		}
+	}
+
+	@JsonPropertyOrder({"datetime", "migration", "fromState", "toState", "successful"})
+	private static class MigrationLog
+	{
+		private final UUID migration;
+		private final String fromState;
+		private final String toState;
+		private final boolean successful;
+		private final Date datetime;
+
+		public MigrationLog(MigrationEvent event)
+		{
+			Migration _migration = event.getElementResource();
+			migration = _migration.getMigrationId();
+			fromState = _migration.getFromState().isPresent() ? _migration.getFromState().get() : "";
+			toState = _migration.getToState().isPresent() ? _migration.getToState().get() : "";
+			datetime = new Date();
+
+			switch (MigrationEvent.Name.valueOf(event.getName()))
+			{
+				case COMPLETE:
+					successful = true;
+					break;
+				case FAILED:
+				default:
+					successful = false;
+					break;
+			}
+		}
+
+		public UUID getMigration()
+		{
+			return migration;
+		}
+
+		public String getFromState()
+		{
+			return fromState;
+		}
+
+		public String getToState()
+		{
+			return toState;
+		}
+
+		public boolean isSuccessful()
+		{
+			return successful;
+		}
+
+		public Date getDatetime()
+		{
+			return datetime;
+		}
+
+	}
+}

--- a/MV.Wildebeest.Core/source/core/java/co/mv/wb/event/TeeEventSink.java
+++ b/MV.Wildebeest.Core/source/core/java/co/mv/wb/event/TeeEventSink.java
@@ -16,28 +16,30 @@
 
 package co.mv.wb.event;
 
-import co.mv.wb.framework.ArgumentNullException;
-import org.slf4j.Logger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
- * An {@link EventSink} that sends the output to the logger at INFO level.
+ * An {@link EventSink} that distributes the event to different EventSinks.
  *
  * @since 4.0
  */
-public class LoggingEventSink implements EventSink
+public class TeeEventSink implements EventSink
 {
-	private final Logger logger;
+	private final List<EventSink> eventSinks;
 
-	public LoggingEventSink(Logger logger)
+	public TeeEventSink(
+		EventSink eventSink,
+		EventSink... moreEventSink)
 	{
-		if (logger == null) throw new ArgumentNullException("logger");
-
-		this.logger = logger;
+		eventSinks = new ArrayList<>();
+		eventSinks.add(eventSink);
+		eventSinks.addAll(Arrays.asList(moreEventSink));
 	}
 
-	@Override
-	public void onEvent(Event event)
+	@Override public void onEvent(Event event)
 	{
-		this.logger.info(event.getMessage().orElse(event.getName()));
+		eventSinks.forEach(eventSink -> eventSink.onEvent(event));
 	}
 }

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplFindPathsUnitTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplFindPathsUnitTests.java
@@ -36,8 +36,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests to verify the {@link WildebeestApiImpl#findPaths(Resource, Optional, Optional)}} and
- * {@link WildebeestApiImpl#findPaths(Resource, Optional, Optional)} methods.
+ * Tests to verify the {@link WildebeestApiImpl#findPaths(Resource, UUID, UUID)}} and
+ * {@link WildebeestApiImpl#findPaths(Resource, UUID, UUID)} methods.
  *
  * @since 4.0
  */

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplMigrateIntegrationTests.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/impl/WildebeestApiImplMigrateIntegrationTests.java
@@ -32,6 +32,8 @@ import co.mv.wb.UnknownStateSpecifiedException;
 import co.mv.wb.Wildebeest;
 import co.mv.wb.WildebeestApi;
 import co.mv.wb.event.LoggingEventSink;
+import co.mv.wb.event.MigrationEventSink;
+import co.mv.wb.event.TeeEventSink;
 import co.mv.wb.plugin.base.ImmutableState;
 import co.mv.wb.plugin.base.ResourceImpl;
 import co.mv.wb.plugin.fake.FakeConstants;
@@ -53,7 +55,7 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Integration tests for the {@link WildebeestApi#migrate(Resource, Instance, Optional)} implementation on
+ * Integration tests for the {@link WildebeestApi#(Resource, Instance, String)} implementation on
  * {@link WildebeestApiImpl}.
  *
  * @since 4.0

--- a/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/fake/SetTagMigrationPlugin.java
+++ b/MV.Wildebeest.Core/source/test/java/co/mv/wb/plugin/fake/SetTagMigrationPlugin.java
@@ -59,7 +59,6 @@ public class SetTagMigrationPlugin implements MigrationPlugin
 		if (migrationT == null)
 		{
 			String msg = "migration must be a SetTagMigration";
-			eventSink.onEvent(MigrationEvent.failed(msg));
 			throw new IllegalArgumentException(msg);
 		}
 
@@ -67,7 +66,6 @@ public class SetTagMigrationPlugin implements MigrationPlugin
 		if (instanceT == null)
 		{
 			String msg = "instance must be a FakeInstance";
-			eventSink.onEvent(MigrationEvent.failed(msg));
 			throw new IllegalArgumentException(msg);
 		}
 


### PR DESCRIPTION
a.  Added MigrationEventSink for logging key Complete and Failed MigrationEvents
b.  Added TeeEventSink for distributing events to LoggingEventSink and MigrationEventSink
c.  Added ResourceEvent for Events that are generated by resource elements.
d.  Added a seperate logger for logging migration events to migration.log
e.  Set debug mode of log4 to false to remove log4j initialisation logs.
f.  Modified WildebeestCommand to use TeeEventSink with LoggingEventSink and MigrationEventSink
g.  Modified WildebeestApiImpl to generate StateEvents in the correct location where the resource element is available.
h.  Added Jackson library for easy generation of JSON from POJOs.